### PR TITLE
Add FileUpload and TextArea components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chargetrip/internal-vue-components",
-  "version": "0.0.493",
+  "version": "0.0.494",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/components/file-upload/FileUpload.vue
+++ b/src/components/file-upload/FileUpload.vue
@@ -184,5 +184,9 @@ export default class CFileUpload extends FormControlProps {
       }
     }
   }
+
+  .box {
+    @apply h-auto min-h-14;
+  }
 }
 </style>

--- a/src/components/file-upload/FileUpload.vue
+++ b/src/components/file-upload/FileUpload.vue
@@ -1,0 +1,188 @@
+<template>
+  <FormControl
+    class="c-fileupload"
+    v-bind="$props"
+    :label-inside="true"
+    :focus="focus"
+    :label-always-visible="true"
+    @click.native="() => (disabled ? null : input.focus())"
+    @hover="$emit('hover', $event)"
+    :class="{
+      'has-prefix': prefix,
+      'has-value': hasValue,
+      'has-focus': focus,
+      'has-label': label
+    }"
+  >
+    <div
+      class="bg-base box flex-1 border-alt border border-dashed rounded px-4 text-font-alt3"
+    >
+      <div class="py-4 flex items-center relative">
+        <span :class="`icon-${icon} text-16 mr-3 pointer-events-none`" />
+        <p class="pointer-events-none">
+          <strong v-if="multiple">
+            Drag files here&hellip;
+          </strong>
+          <strong v-else>
+            Drag file here&hellip;
+          </strong>
+        </p>
+        <Button color="alt" class="relative ml-auto" size="sm">
+          Browse
+        </Button>
+        <input
+          ref="input"
+          class="absolute w-full h-full top-0 left-0 opacity-0"
+          type="file"
+          :files="files"
+          :multiple="multiple"
+          :accept="filetypes.length ? filetypes.join(',') : null"
+          :disabled="disabled"
+          @mouseenter="setHover(true)"
+          @mouseleave="setHover(false)"
+          @focus="setFocus(true)"
+          @input="onInput"
+          @blur="onBlur"
+        />
+      </div>
+      <ul class="list" v-if="this.files.length">
+        <li
+          class="flex items-center justify-between"
+          v-for="(file, index) in this.files"
+          :key="`${file.name}-${file.lastModified}-${file.size}`"
+        >
+          {{ file.name }}
+          <button class="icon-delete w-4 h-4" @click="removeFile(index)" />
+        </li>
+      </ul>
+    </div>
+  </FormControl>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Ref, Emit } from "vue-property-decorator";
+import { Listen } from "@/utilities/decorators";
+import FormControl from "@/components/form-control/FormControl.vue";
+import Button from "@/components/button/Button.vue";
+import { FormControlProps } from "@/utilities/utilities";
+
+@Component({
+  components: { FormControl, Button }
+})
+export default class CFileUpload extends FormControlProps {
+  @Prop({ default: false }) public multiple!: boolean;
+  @Prop({ default: () => [] }) public filetypes!: Array<string>;
+  @Prop({ default: "circle-arrow-down" }) public icon!: string;
+  @Ref("input") public input!: HTMLInputElement;
+
+  public focus = false;
+  public hover = false;
+  private files: Array<File> = [];
+
+  @Listen("keyup") public onKeyDown(event: KeyboardEvent) {
+    event.preventDefault();
+  }
+
+  @Listen("keypress") public onKeypress(event: KeyboardEvent) {
+    if (!this.hotkey) return;
+
+    if (event.key === this.hotkey.key) {
+      event.preventDefault();
+      this.hotkey.fn(this.input);
+    }
+  }
+
+  public removeFile(index: number): void {
+    // Remove the selected file.
+    this.files.splice(index, 1);
+  }
+
+  // Upload element
+  private get upload(): HTMLInputElement {
+    return this.$refs.input as HTMLInputElement;
+  }
+
+  public onInput(): void {
+    const files: ReadonlyArray<File> = [...(this.upload.files ?? [])];
+
+    // Clear the file buffer.
+    this.files = [];
+
+    // Push ReadonlyArray contents to an array to allow for mutation.
+    for (const file of files) {
+      this.files.push(file);
+    }
+
+    this.$emit("input", this.files.length ? this.files : []);
+  }
+
+  @Emit("focus")
+  public setFocus(val: boolean): boolean {
+    this.focus = val;
+
+    return val;
+  }
+
+  @Emit("blur")
+  @Emit("input")
+  public onBlur(): Array<File> {
+    this.setFocus(false);
+
+    return this.files;
+  }
+
+  @Emit("hover")
+  public setHover(val: boolean): boolean {
+    this.hover = val;
+
+    return val;
+  }
+
+  get hasValue(): boolean {
+    return this.files.length > 0 || this.focus;
+  }
+}
+</script>
+
+<style lang="scss">
+.c-fileupload {
+  input[type="file"] {
+    /* While the <input> element might be visually hidden, if the `font-size`
+     * is not set to '0', hovering over the (hidden) "Browse files" text will 
+     * change the cursor to 'auto' / 'default'.
+     */
+    @apply cursor-pointer text-0;
+  }
+
+  &.disabled {
+    input[type="file"] {
+      @apply cursor-not-allowed;
+    }
+  }
+
+  &.has-label {
+    &.label-always-visible .hotkey {
+      @apply mr-3;
+    }
+    input {
+      @apply pt-4;
+    }
+  }
+
+  & .list {
+    @apply flex flex-col gap-4 border-alt border-t py-4;
+
+    & button:hover {
+      @apply text-warning;
+    }
+  }
+
+  &:not(.error) {
+    &.has-hover {
+      .box {
+        @apply bg-base;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/file-upload/index.ts
+++ b/src/components/file-upload/index.ts
@@ -1,0 +1,8 @@
+import FileUpload from "./FileUpload.vue";
+
+// @ts-ignore
+FileUpload.install = Vue => {
+  Vue.component(FileUpload.name, FileUpload);
+};
+
+export default FileUpload;

--- a/src/components/form-control/FormControl.vue
+++ b/src/components/form-control/FormControl.vue
@@ -65,16 +65,17 @@ export default class CFormControl extends FormControlProps {
     this.orientation = window.innerWidth < 720 ? "bottom" : "right";
   }
 
-  @Emit("focus") public setFocus(val) {
+  @Emit("focus") public setFocus(val: boolean): boolean {
     return val;
   }
 
-  @Emit("blur") public onBlur(event) {
+  @Emit("blur") public onBlur(event: FocusEvent): string {
     this.setFocus(false);
-    return event.target.value;
+
+    return (event.target as HTMLInputElement).value;
   }
 
-  @Emit("hover") public setHover(val) {
+  @Emit("hover") public setHover(val: boolean): boolean {
     this.hover = val;
 
     return val;
@@ -130,19 +131,25 @@ export default class CFormControl extends FormControlProps {
       &.has-value {
         label {
           --tw-scale-y: 0.85;
-          --tw-translate-x: 2px;
+          /* Visually align label with input text below by offsetting it on
+           * the x-axis. When scaled down by 15%.
+           *
+           * The value used is:
+           * (1.0 - scale) * 1.0 rem = 0.15 * 1.0 rem = 0.15 rem
+           */
+          --tw-translate-x: 0.15rem;
           --tw-translate-y: -100%;
           --tw-scale-x: 0.85;
         }
       }
       .box,
       &.box {
-        @apply h-14;
+        @apply h-auto min-h-14;
       }
     }
     &.label-inside {
       label {
-        @apply absolute transform top-1/2 left-0 -translate-y-1/2 px-3;
+        @apply absolute transform top-7 left-0 -translate-y-1/2 px-3;
       }
     }
   }
@@ -204,12 +211,12 @@ export default class CFormControl extends FormControlProps {
     }
   }
   .box {
-    @apply h-8 bg-base transition-colors duration-300 rounded-md text-14 text-font-primary outline-none border border-alt2 font-semibold;
+    @apply h-auto min-h-14 bg-base transition-colors duration-300 rounded-md text-14 text-font-primary outline-none border border-alt2 font-semibold;
   }
 
   .suffix,
   .prefix {
-    @apply px-2 min-w-10 flex items-center justify-center border-alt2 h-full text-font-alt2 flex-shrink-0 transition-colors duration-300;
+    @apply h-auto px-2 min-w-10 flex items-center justify-center border-alt2 text-font-alt2 flex-shrink-0 transition-colors duration-300;
   }
 
   .placeholder {
@@ -255,6 +262,18 @@ export default class CFormControl extends FormControlProps {
     &[type="number"] {
       -moz-appearance: textfield;
     }
+  }
+
+  textarea {
+    @apply outline-none w-full h-full bg-transparent px-3 font-semibold shadow-none mt-3 mb-2;
+    resize: none;
+    &::placeholder {
+      @apply text-font-alt3;
+    }
+  }
+
+  label + textarea {
+    @apply mt-7;
   }
 }
 </style>

--- a/src/components/form-control/FormControl.vue
+++ b/src/components/form-control/FormControl.vue
@@ -131,25 +131,19 @@ export default class CFormControl extends FormControlProps {
       &.has-value {
         label {
           --tw-scale-y: 0.85;
-          /* Visually align label with input text below by offsetting it on
-           * the x-axis. When scaled down by 15%.
-           *
-           * The value used is:
-           * (1.0 - scale) * 1.0 rem = 0.15 * 1.0 rem = 0.15 rem
-           */
-          --tw-translate-x: 0.15rem;
+          --tw-translate-x: 2px;
           --tw-translate-y: -100%;
           --tw-scale-x: 0.85;
         }
       }
       .box,
       &.box {
-        @apply h-auto min-h-14;
+        @apply h-14;
       }
     }
     &.label-inside {
       label {
-        @apply absolute transform top-7 left-0 -translate-y-1/2 px-3;
+        @apply absolute transform top-1/2 left-0 -translate-y-1/2 px-3;
       }
     }
   }
@@ -211,12 +205,12 @@ export default class CFormControl extends FormControlProps {
     }
   }
   .box {
-    @apply h-auto min-h-14 bg-base transition-colors duration-300 rounded-md text-14 text-font-primary outline-none border border-alt2 font-semibold;
+    @apply h-8 bg-base transition-colors duration-300 rounded-md text-14 text-font-primary outline-none border border-alt2 font-semibold;
   }
 
   .suffix,
   .prefix {
-    @apply h-auto px-2 min-w-10 flex items-center justify-center border-alt2 text-font-alt2 flex-shrink-0 transition-colors duration-300;
+    @apply px-2 min-w-10 flex items-center justify-center border-alt2 h-full text-font-alt2 flex-shrink-0 transition-colors duration-300;
   }
 
   .placeholder {
@@ -262,18 +256,6 @@ export default class CFormControl extends FormControlProps {
     &[type="number"] {
       -moz-appearance: textfield;
     }
-  }
-
-  textarea {
-    @apply outline-none w-full h-full bg-transparent px-3 font-semibold shadow-none mt-3 mb-2;
-    resize: none;
-    &::placeholder {
-      @apply text-font-alt3;
-    }
-  }
-
-  label + textarea {
-    @apply mt-7;
   }
 }
 </style>

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -17,7 +17,7 @@
     <div class="flex box">
       <div class="prefix" v-if="prefix" v-html="prefix" />
       <div
-        class="icon h-full flex items-center text-font-alt3 pl-2"
+        class="icon h-auto flex items-center text-font-alt3 pl-2"
         v-if="icon"
         :class="`icon-${icon}`"
       />
@@ -163,7 +163,7 @@ export default class CInput extends FormControlProps {
 .c-input {
   &[disabled] {
     input {
-      @apply text-font-alt3 opacity-50 opacity-50 pointer-events-none;
+      @apply text-font-alt3 opacity-50 pointer-events-none;
     }
   }
   &.has-label {

--- a/src/components/input/Input.vue
+++ b/src/components/input/Input.vue
@@ -17,7 +17,7 @@
     <div class="flex box">
       <div class="prefix" v-if="prefix" v-html="prefix" />
       <div
-        class="icon h-auto flex items-center text-font-alt3 pl-2"
+        class="icon h-full flex items-center text-font-alt3 pl-2"
         v-if="icon"
         :class="`icon-${icon}`"
       />

--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -19,7 +19,7 @@
       ref="selectedEl"
     >
       <div
-        class="divider-r flex flex-col h-auto justify-center overflow-hidden flex-1 px-3"
+        class="divider-r flex flex-col h-full justify-center overflow-hidden flex-1 px-3"
       >
         <label v-if="label" v-html="label" />
         <div class="placeholder" v-if="placeholder && !isSelected">

--- a/src/components/select/Select.vue
+++ b/src/components/select/Select.vue
@@ -19,7 +19,7 @@
       ref="selectedEl"
     >
       <div
-        class="divider-r flex flex-col h-full justify-center overflow-hidden flex-1 px-3"
+        class="divider-r flex flex-col h-auto justify-center overflow-hidden flex-1 px-3"
       >
         <label v-if="label" v-html="label" />
         <div class="placeholder" v-if="placeholder && !isSelected">

--- a/src/components/text-area/TextArea.vue
+++ b/src/components/text-area/TextArea.vue
@@ -149,6 +149,7 @@ export default class CTextArea extends FormControlProps {
       @apply text-font-alt3 opacity-50 pointer-events-none;
     }
   }
+
   &.has-label {
     &.label-always-visible {
       .hotkey {
@@ -157,10 +158,32 @@ export default class CTextArea extends FormControlProps {
       textarea {
         @apply mt-3;
       }
+      label {
+        @apply top-7;
+      }
       label + textarea {
         @apply mt-6;
       }
+      .box {
+        @apply h-auto min-h-14;
+      }
     }
+  }
+
+  .box {
+    @apply h-auto min-h-14;
+  }
+
+  textarea {
+    @apply outline-none w-full h-full bg-transparent px-3 font-semibold shadow-none mt-3 mb-2;
+    resize: none;
+    &::placeholder {
+      @apply text-font-alt3;
+    }
+  }
+
+  label + textarea {
+    @apply mt-7;
   }
 }
 </style>

--- a/src/components/text-area/TextArea.vue
+++ b/src/components/text-area/TextArea.vue
@@ -1,0 +1,166 @@
+<template>
+  <FormControl
+    class="c-textarea"
+    v-bind="$props"
+    :label-inside="true"
+    :focus="focus"
+    :label-always-visible="true"
+    @click.native="() => (disabled ? null : textarea.focus())"
+    @hover="$emit('hover', $event)"
+    :class="{
+      'has-prefix': prefix,
+      'has-value': hasValue,
+      'has-focus': focus,
+      'has-label': label
+    }"
+  >
+    <div class="flex box">
+      <div class="prefix" v-if="prefix" v-html="prefix" />
+      <div
+        class="icon h-auto flex items-center text-font-alt3 pl-2"
+        v-if="icon"
+        :class="`icon-${icon}`"
+      />
+      <div class="flex flex-col relative flex-1">
+        <label
+          class="pointer-events-none"
+          :for="id"
+          v-if="label"
+          v-html="label"
+        />
+        <textarea
+          ref="textarea"
+          :rows="rows"
+          :value="value"
+          :id="id"
+          :name="name"
+          :maxlength="maxlength"
+          :autocomplete="autocomplete"
+          :readonly="readonly || disabled"
+          :placeholder="placeholder"
+          @keyup.stop
+          @mouseenter="setHover(true)"
+          @mouseleave="setHover(false)"
+          @focus="setFocus(true)"
+          @paste="$emit('paste', $event)"
+          @blur="onBlur"
+          @input="onInput"
+        />
+        <span
+          class="icon-checkmark absolute top-1/2 transform text-16 -translate-y-1/2 right-0 mr-3 text-accent"
+          v-if="showCheckmark && validation && !validation.$invalid"
+        />
+      </div>
+      <div
+        class="icon hotkey bg-alt2 flex items-center justify-center w-5 h-5 rounded-sm my-auto mr-1"
+        :class="`icon-${hotkey.icon}`"
+        v-if="hotkey"
+      />
+      <div class="suffix" v-if="suffix">
+        {{ suffix }}
+      </div>
+    </div>
+  </FormControl>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Ref, Emit } from "vue-property-decorator";
+import { Listen } from "@/utilities/decorators";
+import FormControl from "@/components/form-control/FormControl.vue";
+import { FormControlProps } from "@/utilities/utilities";
+
+@Component({
+  components: { FormControl }
+})
+export default class CTextArea extends FormControlProps {
+  @Prop() public maxlength!: number;
+  @Prop() public autoresize!: boolean;
+  @Prop({ default: 1 }) public rows!: number;
+
+  @Ref("textarea") public textarea!: HTMLTextAreaElement;
+  public focus = false;
+  public hover = false;
+
+  @Listen("keyup") public onKeyDown(e) {
+    e.preventDefault();
+  }
+
+  @Listen("keypress") public onKeypress(e) {
+    if (!this.hotkey) return;
+
+    if (e.key === this.hotkey.key) {
+      e.preventDefault();
+      this.hotkey.fn(this.textarea);
+    }
+  }
+
+  public onInput(event: InputEvent): void {
+    const elem = event.currentTarget as HTMLTextAreaElement;
+    const value = elem.value;
+
+    if (this.autoresize) {
+      // If the inner height is greater than the content height
+      elem.style.height = "auto";
+      // If the content height is greater than the inner height
+      elem.style.height = elem.scrollHeight + "px";
+    }
+
+    this.$emit(
+      "input",
+      this.maxlength ? value.slice(0, this.maxlength) : value,
+      event
+    );
+  }
+
+  @Emit("focus") public setFocus(val) {
+    this.focus = val;
+    return val;
+  }
+
+  @Emit("blur")
+  @Emit("input")
+  public onBlur(event) {
+    this.setFocus(false);
+
+    return event.target.value;
+  }
+
+  @Emit("hover") public setHover(val) {
+    this.hover = val;
+    return val;
+  }
+
+  get hasValue() {
+    return (
+      (this.value && this.value.toString().length) ||
+      this.focus ||
+      this.placeholder
+    );
+  }
+}
+</script>
+
+<style lang="scss">
+.c-textarea {
+  @apply bg-none;
+
+  &[disabled] {
+    textarea {
+      @apply text-font-alt3 opacity-50 pointer-events-none;
+    }
+  }
+  &.has-label {
+    &.label-always-visible {
+      .hotkey {
+        @apply mr-3;
+      }
+      textarea {
+        @apply mt-3;
+      }
+      label + textarea {
+        @apply mt-6;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/text-area/index.ts
+++ b/src/components/text-area/index.ts
@@ -1,0 +1,8 @@
+import TextArea from "./TextArea.vue";
+
+// @ts-ignore
+TextArea.install = Vue => {
+  Vue.component(TextArea.name, TextArea);
+};
+
+export default TextArea;

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ export { default as TopNav } from "./components/top-nav";
 export { default as WebsiteHeader } from "./components/website-header";
 export { default as Prefooter } from "./components/prefooter";
 export { default as HeightMap } from "./components/height-map";
+export { default as TextArea } from "./components/text-area";
 
 //directives
 export { default as LazyLoadDirective } from "./directives/lazy-load";

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ export { default as WebsiteHeader } from "./components/website-header";
 export { default as Prefooter } from "./components/prefooter";
 export { default as HeightMap } from "./components/height-map";
 export { default as TextArea } from "./components/text-area";
+export { default as FileUpload } from "./components/file-upload";
 
 //directives
 export { default as LazyLoadDirective } from "./directives/lazy-load";

--- a/src/stories/CompactCard.stories.js
+++ b/src/stories/CompactCard.stories.js
@@ -81,7 +81,7 @@ Button.args = {
     title: "title",
     color: "note",
     size: "sm",
-    icon: "arrow-circle-up",
+    icon: "circle-arrow-up",
     callback: console.log
   }
 };

--- a/src/stories/FileUpload.stories.js
+++ b/src/stories/FileUpload.stories.js
@@ -1,0 +1,101 @@
+import Theme from "../components/theme/Theme.vue";
+import FileUpload from "../components/file-upload/FileUpload.vue";
+import Button from "../components/button/Button.vue";
+import "../assets/styles/index.scss";
+import { icons } from "./utils";
+import "./storybook.css";
+import { validationMixin } from "vuelidate";
+
+export default {
+  title: "Form/FileUpload",
+  component: FileUpload,
+  argTypes: {
+    icon: { options: icons, control: { type: "select" } },
+    filetypes: { control: { type: "object" } },
+    hotkey: { control: { type: "object" } },
+    multiple: { control: { type: "boolean" } },
+    disabled: { control: { type: "boolean" } },
+    darkMode: { control: { type: "boolean" } }
+  }
+};
+
+const Template = (args, { argTypes }) => {
+  return {
+    props: Object.keys(argTypes),
+    components: { FileUpload, Button, Theme },
+    mixins: [validationMixin],
+    data() {
+      return {
+        errorMessages: {
+          requireOneJPEG: "At least one jpeg file should be attached",
+          maxBytes: "Attached files should be less than 20 MB"
+        },
+        form: {
+          fileupload1: null,
+          fileupload2: null
+        }
+      };
+    },
+    validations: {
+      form: {
+        fileupload1: {
+          maxBytes: files => {
+            console.log(files);
+            // Whether the selected files are less than 20 MiB (20971520 bytes).
+            return (
+              (files ?? []).reduce((sum, file) => sum + file.size, 0) < 20971520
+            );
+          }
+        },
+        fileupload2: {
+          requireOneJPEG: files => {
+            // Whether there is at least one `jpeg` file selected
+            return (files ?? []).some(file => file.type === "image/jpeg");
+          }
+        }
+      }
+    },
+    methods: {
+      submit() {
+        this.$v.$touch();
+      }
+    },
+    template: `<Theme :dark-mode="darkMode">
+      <div class="grid grid-cols-1 gap-4 content-start max-w-lg">
+        <p>Require the file(s) to be less than 20 MiB.</p>
+        <FileUpload
+          v-model="$v.form.fileupload1.$model"
+          :rules="errorMessages"
+          :error-message="null"
+          :form="$v"
+          :validation="$v.form.fileupload1"
+          v-bind="$props"
+          rules-title="File requirements"
+        />
+        <p>Require at least one <code>jpeg</code> file(s) to be added.</p>
+        <FileUpload
+          v-model="$v.form.fileupload2.$model"
+          :rules="errorMessages"
+          :error-message="null"
+          :form="$v"
+          :validation="$v.form.fileupload2"
+          v-bind="$props"
+          rules-title="File requirements"
+        />
+        <Button @click.native="submit" color="accent" size="md">
+          Submit
+        </Button>
+      </div>
+    </Theme>`
+  };
+};
+
+export const Single = Template.bind({});
+Single.args = {
+  multiple: false
+};
+
+export const Multiple = Template.bind({});
+Multiple.args = {
+  multiple: true
+};

--- a/src/stories/TextArea.stories.js
+++ b/src/stories/TextArea.stories.js
@@ -1,0 +1,110 @@
+import Theme from "../components/theme/Theme.vue";
+import TextArea from "../components/text-area/TextArea.vue";
+
+import "../assets/styles/index.scss";
+import { icons } from "./utils";
+import "./storybook.css";
+import { validationMixin } from "vuelidate";
+import { required } from "vuelidate/lib/validators";
+
+export default {
+  title: "Form/TextArea",
+  component: TextArea,
+  argTypes: {
+    placeholder: { control: { type: "text" } },
+    label: { control: { type: "text" } },
+    prefix: { control: { type: "text" } },
+    suffix: { control: { type: "text" } },
+    icon: { options: icons, control: { type: "select" } },
+    hotkey: { control: { type: "object" } },
+    disabled: { control: { type: "boolean" } },
+    darkMode: { control: { type: "boolean" } },
+    autoresize: {
+      control: { type: "boolean" },
+      description: "Dynamically resize TextArea as text grows larger/smaller"
+    },
+    rows: {
+      control: { type: "number", min: 1, step: 1 },
+      description: "Number of default rows for the TextArea"
+    }
+  }
+};
+
+const Template = (args, { argTypes }) => {
+  return {
+    props: Object.keys(argTypes),
+    components: { TextArea, Theme },
+    mixins: [validationMixin],
+    data() {
+      return {
+        errorMessages: {
+          minLength: "14 or more characters",
+          specialCharacter: "Contains a special character",
+          lowerCharacter: "Contains a lowercase character",
+          upperCharacter: "Contains an uppercase character"
+        },
+        form: {
+          textarea1: null,
+          textarea2: "",
+          textarea3: ""
+        }
+      };
+    },
+    validations: {
+      form: {
+        textarea1: {
+          minLength: value => value?.length >= 14
+        },
+        textarea2: {
+          minLength: value => value?.length >= 14,
+          required
+        },
+        textarea3: {
+          required
+        }
+      }
+    },
+    methods: {
+      submit() {
+        this.$v.$touch();
+      }
+    },
+    template: `<Theme :dark-mode="darkMode">
+      <div class="grid grid-cols-1 gap-2 content-start max-w-lg">
+        <TextArea
+          v-model="$v.form.textarea1.$model"
+          :rules="errorMessages"
+          :error-message="null"
+          :form="$v"
+          :validation="$v.form.textarea1"
+          v-bind="$props"
+          rules-title="Example rules"
+        />
+        <TextArea
+          v-model="$v.form.textarea2.$model"
+          :validation="$v.$dirty && $v.form.textarea2"
+          error-message="Error!@"
+          v-bind="$props"
+        />
+        <TextArea
+          v-model="$v.form.textarea3.$model"
+          :validation="$v.$dirty && $v.form.textarea3"
+          error-message="Error!@"
+          v-bind="$props"
+        />
+      </div>
+    </Theme>`
+  };
+};
+
+export const Label = Template.bind({});
+Label.args = {
+  label: "Label",
+  rows: 1
+};
+
+export const Placeholder = Template.bind({});
+Placeholder.args = {
+  placeholder: "You're on! Provide us with some background information.",
+  rows: 1
+};

--- a/src/stories/utils.js
+++ b/src/stories/utils.js
@@ -62,7 +62,7 @@ export const icons = [
   "clipboard",
   "edit",
   "delete",
-  "arrow-circle-up",
+  "circle-arrow-up",
   "side-panel-bottom",
   "side-panel-top",
   "side-panel-right",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -38,6 +38,9 @@ module.exports = {
           ...negative(theme("spacing"))
         };
       },
+      minHeight: theme => ({
+        ...theme("spacing")
+      }),
       flex: {
         1: 1,
         2: 2,

--- a/tests/storyshots/__snapshots__/index.test.js.snap
+++ b/tests/storyshots/__snapshots__/index.test.js.snap
@@ -1548,55 +1548,104 @@ exports[`Storyshots Components/Button Colors 1`] = `
 <main
   class="theme antialiased font-body text-font-primary bg-body theme-light"
 >
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="note"
+  <button
+    class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 mb-2 last:mb-0 note md skeleton"
     loop="loop"
-    size="md"
-    title="Button"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="base"
+  >
+    <span
+      class="block truncate mx-auto"
+    >
+      
+    Button
+    
+    </span>
+     
+    <!---->
+  </button>
+  <button
+    class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 mb-2 last:mb-0 base md skeleton"
     loop="loop"
-    size="md"
-    title="Button"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="body"
+  >
+    <span
+      class="block truncate mx-auto"
+    >
+      
+    Button
+    
+    </span>
+     
+    <!---->
+  </button>
+  <button
+    class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 mb-2 last:mb-0 body md skeleton"
     loop="loop"
-    size="md"
-    title="Button"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="body-alt"
+  >
+    <span
+      class="block truncate mx-auto"
+    >
+      
+    Button
+    
+    </span>
+     
+    <!---->
+  </button>
+  <button
+    class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 mb-2 last:mb-0 body-alt md skeleton"
     loop="loop"
-    size="md"
-    title="Button"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="alt"
+  >
+    <span
+      class="block truncate mx-auto"
+    >
+      
+    Button
+    
+    </span>
+     
+    <!---->
+  </button>
+  <button
+    class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 mb-2 last:mb-0 alt md skeleton"
     loop="loop"
-    size="md"
-    title="Button"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="accent"
+  >
+    <span
+      class="block truncate mx-auto"
+    >
+      
+    Button
+    
+    </span>
+     
+    <!---->
+  </button>
+  <button
+    class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 mb-2 last:mb-0 accent md skeleton"
     loop="loop"
-    size="md"
-    title="Button"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="error"
+  >
+    <span
+      class="block truncate mx-auto"
+    >
+      
+    Button
+    
+    </span>
+     
+    <!---->
+  </button>
+  <button
+    class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 mb-2 last:mb-0 error md skeleton"
     loop="loop"
-    size="md"
-    title="Button"
-  />
+  >
+    <span
+      class="block truncate mx-auto"
+    >
+      
+    Button
+    
+    </span>
+     
+    <!---->
+  </button>
 </main>
 `;
 
@@ -1679,30 +1728,51 @@ exports[`Storyshots Components/Button Sizes 1`] = `
 <main
   class="theme antialiased font-body text-font-primary bg-body theme-light"
 >
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="accent"
+  <button
+    class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 mb-2 last:mb-0 accent sm skeleton"
     loop="loop"
     openchat="true"
-    size="sm"
-    title="Button"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="accent"
+  >
+    <span
+      class="block truncate mx-auto"
+    >
+      
+    Button
+    
+    </span>
+     
+    <!---->
+  </button>
+  <button
+    class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 mb-2 last:mb-0 accent md skeleton"
     loop="loop"
     openchat="true"
-    size="md"
-    title="Button"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="accent"
+  >
+    <span
+      class="block truncate mx-auto"
+    >
+      
+    Button
+    
+    </span>
+     
+    <!---->
+  </button>
+  <button
+    class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 mb-2 last:mb-0 accent lg skeleton"
     loop="loop"
     openchat="true"
-    size="lg"
-    title="Button"
-  />
+  >
+    <span
+      class="block truncate mx-auto"
+    >
+      
+    Button
+    
+    </span>
+     
+    <!---->
+  </button>
 </main>
 `;
 
@@ -7418,18 +7488,36 @@ exports[`Storyshots Components/Tab Sizes 1`] = `
 <main
   class="theme antialiased font-body text-font-primary bg-body theme-light"
 >
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    loop="loop"
-    size="md"
-    title="Tab"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    loop="loop"
-    size="lg"
-    title="Tab"
-  />
+  <div
+    class="c-tab max-w-full text-14 text-font-primary border border-transparent whitespace-no-wrap select-none leading-none font-semibold transition duration-300 cursor-pointer h-8 px-3 rounded-sm flex items-center justify-center min-w-14 mb-2 last:mb-0 base skeleton"
+  >
+    <span
+      class="title block truncate"
+    >
+      
+    Tab
+  
+    </span>
+     
+    <!---->
+      
+    <!---->
+  </div>
+  <div
+    class="c-tab max-w-full text-14 text-font-primary border border-transparent whitespace-no-wrap select-none leading-none font-semibold transition duration-300 cursor-pointer h-8 px-3 rounded-sm flex items-center justify-center min-w-14 mb-2 last:mb-0 base lg skeleton"
+  >
+    <span
+      class="title block truncate"
+    >
+      
+    Tab
+  
+    </span>
+     
+    <!---->
+      
+    <!---->
+  </div>
 </main>
 `;
 
@@ -7539,36 +7627,61 @@ exports[`Storyshots Components/Tag Colors 1`] = `
 <main
   class="theme antialiased font-body text-font-primary bg-body theme-light"
 >
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="alt"
-    loop="loop"
-    title="Premium"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="alt2"
-    loop="loop"
-    title="Premium"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="accent"
-    loop="loop"
-    title="Premium"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="note"
-    loop="loop"
-    title="Premium"
-  />
-  <dynamiccomp
-    class="mb-2 last:mb-0"
-    color="premium"
-    loop="loop"
-    title="Premium"
-  />
+  <div
+    class="c-tag skeleton flex max-w-full items-center justify-center rounded-2xs h-6 px-2 text-font-primary text-14 font-semibold mb-2 last:mb-0 alt"
+  >
+    <div
+      class="truncate relative z-10"
+    >
+      
+    Premium
+    
+    </div>
+  </div>
+  <div
+    class="c-tag skeleton flex max-w-full items-center justify-center rounded-2xs h-6 px-2 text-font-primary text-14 font-semibold mb-2 last:mb-0 alt2"
+  >
+    <div
+      class="truncate relative z-10"
+    >
+      
+    Premium
+    
+    </div>
+  </div>
+  <div
+    class="c-tag skeleton flex max-w-full items-center justify-center rounded-2xs h-6 px-2 text-font-primary text-14 font-semibold mb-2 last:mb-0 accent"
+  >
+    <div
+      class="truncate relative z-10"
+    >
+      
+    Premium
+    
+    </div>
+  </div>
+  <div
+    class="c-tag skeleton flex max-w-full items-center justify-center rounded-2xs h-6 px-2 text-font-primary text-14 font-semibold mb-2 last:mb-0 note"
+  >
+    <div
+      class="truncate relative z-10"
+    >
+      
+    Premium
+    
+    </div>
+  </div>
+  <div
+    class="c-tag skeleton flex max-w-full items-center justify-center rounded-2xs h-6 px-2 text-font-primary text-14 font-semibold mb-2 last:mb-0 premium"
+  >
+    <div
+      class="truncate relative z-10"
+    >
+      
+    Premium
+    
+    </div>
+  </div>
 </main>
 `;
 
@@ -15358,6 +15471,306 @@ exports[`Storyshots Form/CheckboxTree Toggle All 1`] = `
 </main>
 `;
 
+exports[`Storyshots Form/FileUpload Multiple 1`] = `
+<main
+  class="theme antialiased font-body text-font-primary bg-body theme-light"
+>
+  <div
+    class="grid grid-cols-1 gap-4 content-start max-w-lg"
+  >
+    <p>
+      Require the file(s) to be less than 20 MiB.
+    </p>
+     
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-fileupload skeleton label-inside label-always-visible"
+      filetypes=""
+      multiple="multiple"
+    >
+      <div
+        class="bg-base box flex-1 border-alt border border-dashed rounded px-4 text-font-alt3"
+      >
+        <div
+          class="py-4 flex items-center relative"
+        >
+          <span
+            class="icon-circle-arrow-down text-16 mr-3 pointer-events-none"
+          />
+           
+          <p
+            class="pointer-events-none"
+          >
+            <strong>
+              
+          Drag files here…
+        
+            </strong>
+          </p>
+           
+          <button
+            class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 relative ml-auto alt sm skeleton"
+          >
+            <span
+              class="block truncate mx-auto"
+            >
+              
+    
+    
+        Browse
+      
+            </span>
+             
+            <!---->
+          </button>
+           
+          <input
+            class="absolute w-full h-full top-0 left-0 opacity-0"
+            files=""
+            multiple="multiple"
+            type="file"
+          />
+        </div>
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+     
+    <p>
+      Require at least one 
+      <code>
+        jpeg
+      </code>
+       file(s) to be added.
+    </p>
+     
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-fileupload skeleton label-inside label-always-visible"
+      filetypes=""
+      multiple="multiple"
+    >
+      <div
+        class="bg-base box flex-1 border-alt border border-dashed rounded px-4 text-font-alt3"
+      >
+        <div
+          class="py-4 flex items-center relative"
+        >
+          <span
+            class="icon-circle-arrow-down text-16 mr-3 pointer-events-none"
+          />
+           
+          <p
+            class="pointer-events-none"
+          >
+            <strong>
+              
+          Drag files here…
+        
+            </strong>
+          </p>
+           
+          <button
+            class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 relative ml-auto alt sm skeleton"
+          >
+            <span
+              class="block truncate mx-auto"
+            >
+              
+    
+    
+        Browse
+      
+            </span>
+             
+            <!---->
+          </button>
+           
+          <input
+            class="absolute w-full h-full top-0 left-0 opacity-0"
+            files=""
+            multiple="multiple"
+            type="file"
+          />
+        </div>
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+     
+    <button
+      class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 accent md skeleton"
+    >
+      <span
+        class="block truncate mx-auto"
+      >
+        
+    
+    
+          Submit
+        
+      </span>
+       
+      <!---->
+    </button>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Form/FileUpload Single 1`] = `
+<main
+  class="theme antialiased font-body text-font-primary bg-body theme-light"
+>
+  <div
+    class="grid grid-cols-1 gap-4 content-start max-w-lg"
+  >
+    <p>
+      Require the file(s) to be less than 20 MiB.
+    </p>
+     
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-fileupload skeleton label-inside label-always-visible"
+      filetypes=""
+    >
+      <div
+        class="bg-base box flex-1 border-alt border border-dashed rounded px-4 text-font-alt3"
+      >
+        <div
+          class="py-4 flex items-center relative"
+        >
+          <span
+            class="icon-circle-arrow-down text-16 mr-3 pointer-events-none"
+          />
+           
+          <p
+            class="pointer-events-none"
+          >
+            <strong>
+              
+          Drag file here…
+        
+            </strong>
+          </p>
+           
+          <button
+            class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 relative ml-auto alt sm skeleton"
+          >
+            <span
+              class="block truncate mx-auto"
+            >
+              
+    
+    
+        Browse
+      
+            </span>
+             
+            <!---->
+          </button>
+           
+          <input
+            class="absolute w-full h-full top-0 left-0 opacity-0"
+            files=""
+            type="file"
+          />
+        </div>
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+     
+    <p>
+      Require at least one 
+      <code>
+        jpeg
+      </code>
+       file(s) to be added.
+    </p>
+     
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-fileupload skeleton label-inside label-always-visible"
+      filetypes=""
+    >
+      <div
+        class="bg-base box flex-1 border-alt border border-dashed rounded px-4 text-font-alt3"
+      >
+        <div
+          class="py-4 flex items-center relative"
+        >
+          <span
+            class="icon-circle-arrow-down text-16 mr-3 pointer-events-none"
+          />
+           
+          <p
+            class="pointer-events-none"
+          >
+            <strong>
+              
+          Drag file here…
+        
+            </strong>
+          </p>
+           
+          <button
+            class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 relative ml-auto alt sm skeleton"
+          >
+            <span
+              class="block truncate mx-auto"
+            >
+              
+    
+    
+        Browse
+      
+            </span>
+             
+            <!---->
+          </button>
+           
+          <input
+            class="absolute w-full h-full top-0 left-0 opacity-0"
+            files=""
+            type="file"
+          />
+        </div>
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+     
+    <button
+      class="c-button max-w-full text-white focus:outline-none border border-transparent whitespace-no-wrap transition-all duration-300 px-4 cursor-pointer rounded-sm flex items-center font-semibold text-14 accent md skeleton"
+    >
+      <span
+        class="block truncate mx-auto"
+      >
+        
+    
+    
+          Submit
+        
+      </span>
+       
+      <!---->
+    </button>
+  </div>
+</main>
+`;
+
 exports[`Storyshots Form/Input Label 1`] = `
 <main
   class="theme antialiased font-body text-font-primary bg-body theme-light"
@@ -17389,6 +17802,239 @@ exports[`Storyshots Form/Switch Primary 1`] = `
     <!---->
      
     <!---->
+  </div>
+</main>
+`;
+
+exports[`Storyshots Form/TextArea Label 1`] = `
+<main
+  class="theme antialiased font-body text-font-primary bg-body theme-light"
+>
+  <div
+    class="grid grid-cols-1 gap-2 content-start max-w-lg"
+  >
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-textarea skeleton label-inside label-always-visible has-label"
+      rows="1"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex flex-col relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            Label
+          </label>
+           
+          <textarea
+            rows="1"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+     
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-textarea skeleton has-error-message label-inside label-always-visible has-label"
+      rows="1"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex flex-col relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            Label
+          </label>
+           
+          <textarea
+            rows="1"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+     
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-textarea skeleton has-error-message label-inside label-always-visible has-label"
+      rows="1"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex flex-col relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            Label
+          </label>
+           
+          <textarea
+            rows="1"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Form/TextArea Placeholder 1`] = `
+<main
+  class="theme antialiased font-body text-font-primary bg-body theme-light"
+>
+  <div
+    class="grid grid-cols-1 gap-2 content-start max-w-lg"
+  >
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-textarea skeleton label-inside label-always-visible has-value"
+      rows="1"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex flex-col relative flex-1"
+        >
+          <!---->
+           
+          <textarea
+            placeholder="You're on! Provide us with some background information."
+            rows="1"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+     
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-textarea skeleton has-error-message label-inside label-always-visible has-value"
+      rows="1"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex flex-col relative flex-1"
+        >
+          <!---->
+           
+          <textarea
+            placeholder="You're on! Provide us with some background information."
+            rows="1"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+     
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-textarea skeleton has-error-message label-inside label-always-visible has-value"
+      rows="1"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex flex-col relative flex-1"
+        >
+          <!---->
+           
+          <textarea
+            placeholder="You're on! Provide us with some background information."
+            rows="1"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
   </div>
 </main>
 `;


### PR DESCRIPTION
Rebased on top of the latest `master` branch, this adds two new components and fixes the name of an icon.

1. An expanding `TextArea` component is added that has changed many of the elements by changing the fixed `height` of Tailwind's `h-14` (3.5 rem) to a `min-height` of `h-14`. Combining this with `height: auto` allows for expanding elements, such as a `TextArea`, while still using the `FormControl` element underneath.

2. A `FileUpload` component is added that allows the end user to add files. As the native element doesn't allow one to remove files, due to the use of `ReadonlyArray<File>`, the files are pushed to an internal `Array`, which is mutable.

The icon `arrow-circle-down` has been renamed to match `circle-arrow-down`, as is exported by Figma.
