### PR TITLE
Add masked inputs for calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "imagemin-pngquant": "^9.0.2",
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.21",
+    "maska": "^1.5.0",
     "showdown": "^1.9.1",
     "swiper": "^6.8.0",
     "vue": "^2.6.11",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "highlight.js": "^10.5.0",
     "imagemin": "^8.0.0",
     "imagemin-pngquant": "^9.0.2",
+    "imask": "^6.2.2",
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.21",
     "maska": "^1.5.0",
@@ -34,6 +35,7 @@
     "swiper": "^6.8.0",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
+    "vue-imask": "^6.2.2",
     "vue-property-decorator": "^8.4.2",
     "vue-router": "^3.4.3",
     "vuelidate": "^0.7.6"
@@ -54,6 +56,7 @@
     "@vue/cli-plugin-typescript": "^4.5.0",
     "@vue/cli-plugin-unit-jest": "^4.5.0",
     "@vue/cli-service": "^4.5.6",
+    "@vue/composition-api": "^1.4.4",
     "@vue/eslint-config-prettier": "^6.0.0",
     "@vue/eslint-config-typescript": "^5.0.2",
     "@vue/test-utils": "^1.0.3",

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -51,24 +51,22 @@
         <div
           class="flex justify-between items-center px-4 py-4 border-b border-alt2"
         >
-          <DateInput
+          <MaskedInput
             class="w-full"
-            formatString="dd / MM / yyyy"
-            mask="## / ## / ####"
             placeholder="DD / MM / YYYY"
-            :value="dates[0]"
-            @input="onInputStartDate"
+            :value="startDateString"
+            :maskOptions="dateMask"
+            @complete="onInputStartDate"
             @focus="onFocusStartDate"
           />
           <template v-if="range">
             <div class="mx-2 icon icon-arrow-right" />
-            <DateInput
+            <MaskedInput
               class="w-full"
-              formatString="dd / MM / yyyy"
-              mask="## / ## / ####"
               placeholder="DD / MM / YYYY"
-              :value="dates[1]"
-              @input="onInputEndDate"
+              :value="endDateString"
+              :maskOptions="dateMask"
+              @complete="onInputEndDate"
               @focus="onFocusEndDate"
             />
           </template>
@@ -129,6 +127,10 @@
                 @mouseleave="hoverDate = null"
                 :class="{
                   disabled: disableFuture && isAfterToday(month.value, date),
+                  'is-start-of-week': isStartOfWeek(month.value, date),
+                  'is-start-of-month': isStartOfMonth(month.value, date),
+                  'is-end-of-week': isEndOfWeek(month.value, date),
+                  'is-end-of-month': isEndOfMonth(month.value, date),
                   'is-start-date': isStartDate(month.value, date),
                   'is-end-date': isEndDate(month.value, date),
                   'is-hover-date': isHoverDate(month.value, date),
@@ -136,7 +138,9 @@
                   empty: !date
                 }"
               >
-                {{ date }}
+                <div>
+                  {{ date }}
+                </div>
               </li>
             </ul>
           </div>
@@ -152,6 +156,9 @@ import {
   addMonths,
   compareAsc,
   endOfDay,
+  endOfWeek,
+  endOfMonth,
+  format,
   getDaysInMonth,
   isAfter,
   isBefore,
@@ -161,17 +168,20 @@ import {
   isSameYear,
   isValid,
   setDate,
+  parse,
   startOfDay,
+  startOfWeek,
   startOfMonth
 } from "date-fns";
 import { Listen } from "@/utilities/decorators";
 import date from "@/filters/date";
 import DateInput from "@/components/date-input/DateInput.vue";
+import MaskedInput from "@/components/masked-input/MaskedInput.vue";
 import FormControl from "@/components/form-control/FormControl.vue";
 import { FormControlProps, getPath } from "@/utilities/utilities";
 
 @Component({
-  components: { DateInput, FormControl },
+  components: { MaskedInput, DateInput, FormControl },
   filters: { date }
 })
 export default class CCalendar extends FormControlProps {
@@ -189,10 +199,16 @@ export default class CCalendar extends FormControlProps {
   hoverDate: Date | null = null;
   datePickerOffsetLeft = 0;
 
+  dateMask = {
+    mask: "`00` {/} `00` {/} `0000`",
+    placeholderChar: " ",
+    overwrite: true,
+    lazy: true
+  };
+
   get months() {
     const nextMonth = addMonths(this.currentMonth, 1);
 
-    console.log(this.currentMonth);
     return [
       {
         value: this.currentMonth,
@@ -205,6 +221,14 @@ export default class CCalendar extends FormControlProps {
     ];
   }
 
+  get startDateString(): string {
+    return this.dates[0] ? format(this.dates[0], "dd/MM/yyyy") : "";
+  }
+
+  get endDateString(): string {
+    return this.dates[1] ? format(this.dates[1], "dd/MM/yyyy") : "";
+  }
+
   @Listen("click")
   public onClick(e): void {
     const path = e.path || getPath(e.target);
@@ -214,14 +238,14 @@ export default class CCalendar extends FormControlProps {
     this.setActive(clickedBox ? !this.active : clickedEl);
   }
 
-  public setActive(val: boolean): void {
-    this.active = val;
-  }
+  public onInputStartDate(value: string): void {
+    const parsed = parse(value, "dd/MM/yyyy", new Date());
 
-  public onInputStartDate(date: Date): void {
-    const startDate = startOfDay(date);
+    if (!isValid(parsed)) {
+      return;
+    }
 
-    if (!isValid(startDate)) return;
+    const startDate = startOfDay(parsed);
 
     // Do not update calendar if this date is an invalid future date
     if (this.disableFuture && isAfter(startDate, Date.now())) {
@@ -232,19 +256,25 @@ export default class CCalendar extends FormControlProps {
       this.dates = [startDate, this.dates[1]];
       // Sort start and end date if one that was entered goes past the other
       this.dates.sort(compareAsc);
-      this.$emit("input", [startOfDay(this.dates[0]), endOfDay(this.dates[1])]);
+      this.$emit("input", [startDate, endOfDay(this.dates[1])]);
     } else {
       this.dates = [startDate];
       this.$emit("input", startDate);
     }
+
     // Set the current visible month to the input that was just used.
     this.currentMonth = startOfDay(startDate);
   }
 
-  public onInputEndDate(date: Date): void {
-    const endDate = endOfDay(date);
+  public onInputEndDate(value: string): void {
+    const parsed = parse(value, "dd/MM/yyyy", new Date());
 
-    if (!isValid(endDate)) return;
+    if (!isValid(parsed)) {
+      return;
+    }
+
+    const endDate = endOfDay(parsed);
+
     // Do not update calendar if this date is an invalid future date
     if (this.disableFuture && isAfter(endDate, Date.now())) {
       return;
@@ -253,11 +283,14 @@ export default class CCalendar extends FormControlProps {
     this.dates = [this.dates[0], endDate];
     // Sort start and end date if one that was entered goes past the other
     this.dates.sort(compareAsc);
-    this.$emit("input", [startOfDay(this.dates[0]), endOfDay(this.dates[1])]);
+    this.$emit("input", this.dates);
 
     // Set the current visible month to the input that was just used.
     this.currentMonth = startOfDay(endDate);
-    // eslint-disable-next-line no-empty
+  }
+
+  public setActive(val: boolean): void {
+    this.active = val;
   }
 
   public onFocusStartDate(): void {
@@ -266,18 +299,16 @@ export default class CCalendar extends FormControlProps {
     } else {
       this.$emit("input", this.dates[0]);
     }
-    // Set the current visible month to the input that was just used.
+
     this.currentMonth = startOfDay(this.dates[0]);
   }
 
   public onFocusEndDate(): void {
     if (this.dates.length > 1) {
       this.$emit("input", [startOfDay(this.dates[0]), endOfDay(this.dates[1])]);
-    } else {
-      this.$emit("input", this.dates[1]);
+
+      this.currentMonth = startOfDay(this.dates[1]);
     }
-    // Set the current visible month to the input that was just used.
-    this.currentMonth = startOfDay(this.dates[1]);
   }
 
   public isInRange(month: Date, day: number): boolean {
@@ -320,7 +351,7 @@ export default class CCalendar extends FormControlProps {
     return isBefore(selectedOrHoverDate, this.dates[0]);
   }
 
-  isAfterToday(month, day) {
+  isAfterToday(month: Date, day: number) {
     return isAfter(setDate(month, day), new Date());
   }
 
@@ -336,6 +367,30 @@ export default class CCalendar extends FormControlProps {
     if (!this.dates?.[1]) return false;
 
     return this.isEqual(this.dates[1], setDate(month, day));
+  }
+
+  public isStartOfWeek(month: Date, day: number): boolean {
+    const currentDay = setDate(month, day);
+
+    return isSameDay(startOfWeek(currentDay, { weekStartsOn: 1 }), currentDay);
+  }
+
+  public isEndOfWeek(month: Date, day: number): boolean {
+    const currentDay = setDate(month, day);
+
+    return isSameDay(endOfWeek(currentDay, { weekStartsOn: 1 }), currentDay);
+  }
+
+  public isStartOfMonth(month: Date, day: number): boolean {
+    const currentDay = setDate(month, day);
+
+    return isSameDay(startOfMonth(month), currentDay);
+  }
+
+  public isEndOfMonth(month: Date, day: number): boolean {
+    const currentDay = setDate(month, day);
+
+    return isSameDay(endOfMonth(month), currentDay);
   }
 
   public isHoverDate(month: Date, day: number): boolean {
@@ -418,7 +473,7 @@ export default class CCalendar extends FormControlProps {
         .dates {
           li {
             &:not(.empty) {
-              &.is-range {
+              &.is-range div {
                 background: rgba(0, 120, 255, 0.1);
               }
             }
@@ -431,12 +486,12 @@ export default class CCalendar extends FormControlProps {
 
 .c-calendar {
   &.has-start-and-end {
-    .is-hover-date {
+    .is-hover-date div {
       @apply rounded;
     }
   }
   &:not(.is-range) {
-    .is-start-date {
+    .is-start-date div {
       @apply rounded;
     }
   }
@@ -455,7 +510,11 @@ export default class CCalendar extends FormControlProps {
       .calendar {
         .dates {
           li {
-            &:hover {
+            & div {
+              @apply rounded-md;
+            }
+
+            &:hover div {
               @apply rounded-md;
             }
           }
@@ -468,23 +527,16 @@ export default class CCalendar extends FormControlProps {
     .calendar {
       .dates {
         li {
-          &.is-start-date {
-            @apply rounded-l-md;
+          &.is-start-date div {
+            @apply rounded-md;
           }
 
-          &.is-hover-date,
-          &.is-end-date {
-            @apply rounded-r-md;
+          &.is-hover-date div,
+          &.is-end-date div {
+            @apply rounded-md;
           }
 
-          &.is-start-date.is-hover-date {
-            @apply rounded-r-none;
-          }
-          &.is-end-date.is-hover-date {
-            @apply rounded-l-none;
-          }
-
-          &.is-start-date.is-end-date.is-hover-date {
+          &.is-start-date.is-end-date.is-hover-date div {
             @apply rounded-md;
           }
         }
@@ -496,13 +548,13 @@ export default class CCalendar extends FormControlProps {
     .calendar {
       .dates {
         li {
-          &.is-hover-date,
-          &.is-end-date {
-            @apply rounded-l-md;
+          &.is-hover-date div,
+          &.is-end-date div {
+            @apply rounded-md;
           }
 
-          &.is-start-date {
-            @apply rounded-r-md;
+          &.is-start-date div {
+            @apply rounded-md;
           }
         }
       }
@@ -511,22 +563,100 @@ export default class CCalendar extends FormControlProps {
 
   .calendar {
     li {
-      @apply w-8 h-8 flex items-center justify-center mb-1;
+      @apply box-content w-8 h-8 flex items-center justify-center py-0.5;
     }
 
     .dates {
       li {
-        &.disabled {
+        &:not(.is-start-date) {
+          &.is-start-of-week {
+            div {
+              @apply rounded-l-md;
+            }
+
+            &.is-hover-date div {
+              @apply rounded-md;
+            }
+          }
+
+          &.is-end-of-week {
+            div {
+              @apply rounded-r-md;
+            }
+
+            &.is-hover-date div {
+              @apply rounded-md;
+            }
+          }
+
+          &.is-start-of-month {
+            div {
+              @apply rounded-md;
+            }
+          }
+
+          &.is-end-of-month {
+            div {
+              @apply rounded-md;
+            }
+          }
+        }
+
+        &.is-range {
+          &.is-start-of-month:not(.is-hover-date) {
+            div {
+              @apply rounded-l-md rounded-r-none;
+            }
+          }
+        }
+
+        &.disabled div {
           @apply pointer-events-none opacity-50;
         }
+
         &:not(.empty) {
-          &.is-range {
+          &.is-range div {
             background: rgba(0, 120, 255, 0.2);
           }
-          &.is-start-date,
-          &.is-end-date,
-          &.is-hover-date {
+          &.is-start-date div,
+          &.is-end-date div,
+          &.is-hover-date div {
             @apply bg-accent text-white #{!important};
+          }
+        }
+
+        div {
+          @apply flex w-full h-full justify-center items-center;
+        }
+      }
+    }
+  }
+
+  /* An override for the style applied by FormControl on `.box`, since it
+   * applies to a nested `.box` as well, which we do not want.
+   */
+  .c-masked-input {
+    &.c-form-control {
+      .box {
+        @apply h-8 bg-base transition-colors duration-300 rounded-md text-14 text-font-primary outline-none border border-alt2 font-semibold;
+      }
+
+      &:not(.error) {
+        &.has-hover {
+          .box {
+            @apply bg-alt border-alt3;
+          }
+        }
+
+        &.has-focus {
+          .box {
+            @apply bg-base border-accent;
+          }
+        }
+
+        &.active {
+          .box {
+            @apply border-accent;
           }
         }
       }

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -58,6 +58,7 @@
             placeholder="DD / MM / YYYY"
             :value="dates[0]"
             @input="onInputStartDate"
+            @focus="onFocusStartDate"
           />
           <template v-if="range">
             <div class="mx-2 icon icon-arrow-right" />
@@ -68,6 +69,7 @@
               placeholder="DD / MM / YYYY"
               :value="dates[1]"
               @input="onInputEndDate"
+              @focus="onFocusEndDate"
             />
           </template>
         </div>
@@ -256,6 +258,26 @@ export default class CCalendar extends FormControlProps {
     // Set the current visible month to the input that was just used.
     this.currentMonth = startOfDay(endDate);
     // eslint-disable-next-line no-empty
+  }
+
+  public onFocusStartDate(): void {
+    if (this.dates.length > 1) {
+      this.$emit("input", [startOfDay(this.dates[0]), endOfDay(this.dates[1])]);
+    } else {
+      this.$emit("input", this.dates[0]);
+    }
+    // Set the current visible month to the input that was just used.
+    this.currentMonth = startOfDay(this.dates[0]);
+  }
+
+  public onFocusEndDate(): void {
+    if (this.dates.length > 1) {
+      this.$emit("input", [startOfDay(this.dates[0]), endOfDay(this.dates[1])]);
+    } else {
+      this.$emit("input", this.dates[1]);
+    }
+    // Set the current visible month to the input that was just used.
+    this.currentMonth = startOfDay(this.dates[1]);
   }
 
   public isInRange(month: Date, day: number): boolean {

--- a/src/components/calendar/Calendar.vue
+++ b/src/components/calendar/Calendar.vue
@@ -56,8 +56,8 @@
             formatString="dd / MM / yyyy"
             mask="## / ## / ####"
             placeholder="DD / MM / YYYY"
-            :initialValue="dates[0]"
-            @input-date="onInputStartDate"
+            :value="dates[0]"
+            @input="onInputStartDate"
           />
           <template v-if="range">
             <div class="mx-2 icon icon-arrow-right" />
@@ -66,8 +66,8 @@
               formatString="dd / MM / yyyy"
               mask="## / ## / ####"
               placeholder="DD / MM / YYYY"
-              :initialValue="dates[1]"
-              @input-date="onInputEndDate"
+              :value="dates[1]"
+              @input="onInputEndDate"
             />
           </template>
         </div>
@@ -157,6 +157,7 @@ import {
   isSameDay,
   isSameMonth,
   isSameYear,
+  isValid,
   setDate,
   startOfDay,
   startOfMonth
@@ -189,6 +190,7 @@ export default class CCalendar extends FormControlProps {
   get months() {
     const nextMonth = addMonths(this.currentMonth, 1);
 
+    console.log(this.currentMonth);
     return [
       {
         value: this.currentMonth,
@@ -217,6 +219,8 @@ export default class CCalendar extends FormControlProps {
   public onInputStartDate(date: Date): void {
     const startDate = startOfDay(date);
 
+    if (!isValid(startDate)) return;
+
     // Do not update calendar if this date is an invalid future date
     if (this.disableFuture && isAfter(startDate, Date.now())) {
       return;
@@ -231,7 +235,6 @@ export default class CCalendar extends FormControlProps {
       this.dates = [startDate];
       this.$emit("input", startDate);
     }
-
     // Set the current visible month to the input that was just used.
     this.currentMonth = startOfDay(startDate);
   }
@@ -239,6 +242,7 @@ export default class CCalendar extends FormControlProps {
   public onInputEndDate(date: Date): void {
     const endDate = endOfDay(date);
 
+    if (!isValid(endDate)) return;
     // Do not update calendar if this date is an invalid future date
     if (this.disableFuture && isAfter(endDate, Date.now())) {
       return;
@@ -251,6 +255,7 @@ export default class CCalendar extends FormControlProps {
 
     // Set the current visible month to the input that was just used.
     this.currentMonth = startOfDay(endDate);
+    // eslint-disable-next-line no-empty
   }
 
   public isInRange(month: Date, day: number): boolean {

--- a/src/components/date-input/DateInput.vue
+++ b/src/components/date-input/DateInput.vue
@@ -5,9 +5,11 @@
     v-maska="mask"
     :maxlength="formatString.length"
     :placeholder="placeholder"
-    @input="onInput"
     :value="formattedDate"
     :label="label"
+    :focus="focus"
+    @focus="setFocus(true)"
+    @input="onInput"
   />
 </template>
 
@@ -32,12 +34,20 @@ export default class CDateInput extends FormControlProps {
   // mask="## / ## / ####"
   @Prop({ default: "## / ####" }) readonly mask!: string;
 
+  focus = false;
+
   get formattedDate(): string {
     try {
       return format(this.value!, this.formatString);
     } catch (e) {
       return "";
     }
+  }
+
+  @Emit("focus")
+  public setFocus(value: boolean) {
+    this.focus = value;
+    return value;
   }
 
   @Emit("input")

--- a/src/components/date-input/DateInput.vue
+++ b/src/components/date-input/DateInput.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Prop, Ref } from "vue-property-decorator";
+import { Component, Prop, Ref, Emit } from "vue-property-decorator";
 import Input from "@/components/input/Input.vue";
 import { FormControlProps } from "@/utilities/utilities";
 import { format, isValid, parse, startOfDay } from "date-fns";
@@ -24,30 +24,30 @@ import { maska } from "maska";
 })
 export default class CDateInput extends FormControlProps {
   @Ref("input") public input!: HTMLInputElement;
+  @Prop({ default: null }) readonly value!: Date | null;
   // For valid format tokens, see: https://date-fns.org/v2.28.0/docs/parse
   @Prop({ default: "MM / yyyy" }) readonly formatString!: string;
   // NOTE: If a `mask` is used, make sure that it matches `formatString`, e.g:
   // formatString="dd / MM / yyyy"
   // mask="## / ## / ####"
   @Prop({ default: "## / ####" }) readonly mask!: string;
-  @Prop({ default: null }) readonly initialValue!: Date | null;
 
   get formattedDate(): string {
-    if (this.initialValue) {
-      return format(this.initialValue, this.formatString);
+    try {
+      return format(this.value!, this.formatString);
+    } catch (e) {
+      return "";
     }
-
-    return "";
   }
 
   @Emit("input")
-  public onInput(value: string, _: InputEvent) {
+  public onInput(value: string) {
     // Prevent early parsing of an invalid date
     if (value.length === this.formatString.length) {
       const parsed = parse(value, this.formatString, new Date());
 
       if (isValid(parsed)) {
-        this.$emit("input-date", startOfDay(parsed));
+        return startOfDay(parsed);
       }
     }
 

--- a/src/components/date-input/DateInput.vue
+++ b/src/components/date-input/DateInput.vue
@@ -1,0 +1,57 @@
+<template>
+  <Input
+    class="c-date-input"
+    v-bind="$props"
+    v-maska="mask"
+    :maxlength="formatString.length"
+    :placeholder="placeholder"
+    @input="onInput"
+    :value="formattedDate"
+    :label="label"
+  />
+</template>
+
+<script lang="ts">
+import { Component, Emit, Prop, Ref } from "vue-property-decorator";
+import Input from "@/components/input/Input.vue";
+import { FormControlProps } from "@/utilities/utilities";
+import { format, isValid, parse, startOfDay } from "date-fns";
+import { maska } from "maska";
+
+@Component({
+  components: { Input },
+  directives: { maska }
+})
+export default class CDateInput extends FormControlProps {
+  @Ref("input") public input!: HTMLInputElement;
+  // For valid format tokens, see: https://date-fns.org/v2.28.0/docs/parse
+  @Prop({ default: "MM / yyyy" }) readonly formatString!: string;
+  // NOTE: If a `mask` is used, make sure that it matches `formatString`, e.g:
+  // formatString="dd / MM / yyyy"
+  // mask="## / ## / ####"
+  @Prop({ default: "## / ####" }) readonly mask!: string;
+  @Prop({ default: null }) readonly initialValue!: Date | null;
+
+  get formattedDate(): string {
+    if (this.initialValue) {
+      return format(this.initialValue, this.formatString);
+    }
+
+    return "";
+  }
+
+  @Emit("input")
+  public onInput(value: string, _: InputEvent) {
+    // Prevent early parsing of an invalid date
+    if (value.length === this.formatString.length) {
+      const parsed = parse(value, this.formatString, new Date());
+
+      if (isValid(parsed)) {
+        this.$emit("input-date", startOfDay(parsed));
+      }
+    }
+
+    return value;
+  }
+}
+</script>

--- a/src/components/date-input/index.ts
+++ b/src/components/date-input/index.ts
@@ -1,0 +1,8 @@
+import DateInput from "./DateInput.vue";
+
+// @ts-ignore
+DateInput.install = Vue => {
+  Vue.component(DateInput.name, DateInput);
+};
+
+export default DateInput;

--- a/src/components/masked-input/MaskedInput.vue
+++ b/src/components/masked-input/MaskedInput.vue
@@ -1,0 +1,209 @@
+<template>
+  <FormControl
+    class="c-masked-input"
+    v-bind="$props"
+    :label-inside="true"
+    :focus="focus"
+    :label-always-visible="true"
+    @click.native="() => (disabled ? null : input.focus())"
+    @hover="$emit('hover', $event)"
+    :class="{
+      'has-prefix': prefix,
+      'has-value': hasValue,
+      'has-focus': focus,
+      'has-label': label
+    }"
+  >
+    <div class="flex box">
+      <div class="prefix" v-if="prefix" v-html="prefix" />
+      <div
+        class="icon h-full flex items-center text-font-alt3 pl-2"
+        v-if="icon"
+        :class="`icon-${icon}`"
+      />
+      <div class="flex relative flex-1">
+        <label
+          class="pointer-events-none"
+          :for="id"
+          v-if="label"
+          v-html="label"
+        />
+        <input
+          ref="input"
+          :value="value"
+          :id="id"
+          :name="name"
+          :maxlength="maxlength"
+          :max="max"
+          :autocomplete="autocomplete"
+          :type="type === 'number' ? 'text' : type"
+          :readonly="readonly || disabled"
+          :placeholder="placeholder"
+          @keyup.stop
+          @mouseenter="setHover(true)"
+          @mouseleave="setHover(false)"
+          @focus="setFocus(true)"
+          @paste="$emit('paste', $event)"
+          @blur="onBlur"
+          @input="onInput"
+          v-imask="maskOptions"
+          @accept="onAccept"
+          @complete="onComplete"
+        />
+        <span
+          class="icon-checkmark absolute top-1/2 transform text-16 -translate-y-1/2 right-0 mr-3 text-accent"
+          v-if="showCheckmark && validation && !validation.$invalid"
+        />
+      </div>
+      <div
+        class="icon hotkey bg-alt2 flex items-center justify-center w-5 h-5 rounded-sm my-auto mr-1"
+        :class="`icon-${hotkey.icon}`"
+        v-if="hotkey"
+      />
+      <div class="suffix" v-if="suffix">
+        {{ suffix }}
+      </div>
+    </div>
+  </FormControl>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Ref, Emit } from "vue-property-decorator";
+import { Listen } from "@/utilities/decorators";
+import FormControl from "@/components/form-control/FormControl.vue";
+import { FormControlProps } from "@/utilities/utilities";
+import { IMaskDirective } from "vue-imask";
+
+@Component({
+  components: { FormControl },
+  directives: { imask: IMaskDirective }
+})
+export default class CMaskedInput extends FormControlProps {
+  @Prop() public type!: string;
+  @Prop() public maxlength!: number;
+  @Prop() public max!: number;
+  // For more information on masks and options, see:
+  // https://imask.js.org/guide.html
+  @Prop({
+    default: () => ({
+      mask: "00 {/} 00 {/} `0000",
+      placeholderChar: "_",
+      overwrite: true,
+      lazy: true
+    })
+  })
+  readonly maskOptions!: any;
+
+  @Ref("input") public input!: HTMLInputElement;
+  public focus = false;
+  public hover = false;
+
+  @Listen("keyup") public onKeyDown(e) {
+    e.preventDefault();
+  }
+
+  @Listen("keypress") public onKeypress(e) {
+    if (!this.hotkey) return;
+
+    if (e.key === this.hotkey.key) {
+      e.preventDefault();
+      this.hotkey.fn(this.input);
+    }
+  }
+
+  @Emit("input")
+  public onAccept(): string {
+    return this.value;
+  }
+
+  @Emit("complete")
+  public onComplete(event: any): string {
+    const maskRef = event.detail;
+
+    return maskRef.unmaskedValue;
+  }
+
+  public onInput(e) {
+    const value = this.max
+      ? Math.min(e.target.value, this.max).toString()
+      : e.target.value;
+
+    if (this.type === "number") {
+      const parsed = parseFloat(value.replace(",", "."));
+
+      const replacedValue = parsed.toString().replace(/[^0-9(.|,)]/g, "");
+
+      const normalizedValue = (value[value.length - 1] === "."
+        ? `${replacedValue}.`
+        : replacedValue
+      ).slice(0, this.maxlength || Infinity);
+
+      e.target.value = normalizedValue;
+
+      return this.$emit("input", normalizedValue || null, e);
+    }
+
+    this.$emit(
+      "input",
+      this.maxlength ? value.slice(0, this.maxlength) : value,
+      e
+    );
+  }
+
+  @Emit("focus") public setFocus(val) {
+    this.focus = val;
+    return val;
+  }
+
+  @Emit("blur")
+  @Emit("input")
+  public onBlur(event) {
+    this.setFocus(false);
+
+    if (this.type === "number") {
+      const value = parseFloat(event.target.value);
+
+      return isNaN(value) ? null : value;
+    }
+
+    return event.target.value;
+  }
+
+  @Emit("hover") public setHover(val) {
+    this.hover = val;
+
+    return val;
+  }
+
+  get hasValue() {
+    return (
+      (this.value && this.value.toString().length) ||
+      (this.type === "number" &&
+        !isNaN(this.value as number) &&
+        this.value !== null) ||
+      this.focus ||
+      this.placeholder
+    );
+  }
+}
+</script>
+
+<style lang="scss">
+.c-masked-input {
+  &[disabled] {
+    input {
+      @apply text-font-alt3 opacity-50 pointer-events-none;
+    }
+  }
+  &.has-label {
+    &.label-always-visible {
+      .hotkey {
+        @apply mr-3;
+      }
+      input {
+        @apply pt-4;
+      }
+    }
+  }
+}
+</style>

--- a/src/components/masked-input/index.ts
+++ b/src/components/masked-input/index.ts
@@ -1,0 +1,8 @@
+import MaskedInput from "./MaskedInput.vue";
+
+// @ts-ignore
+MaskedInput.install = Vue => {
+  Vue.component(MaskedInput.name, MaskedInput);
+};
+
+export default MaskedInput;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export { default as Prefooter } from "./components/prefooter";
 export { default as HeightMap } from "./components/height-map";
 export { default as TextArea } from "./components/text-area";
 export { default as FileUpload } from "./components/file-upload";
+export { default as DateInput } from "./components/date-input";
 
 //directives
 export { default as LazyLoadDirective } from "./directives/lazy-load";

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export { default as HeightMap } from "./components/height-map";
 export { default as TextArea } from "./components/text-area";
 export { default as FileUpload } from "./components/file-upload";
 export { default as DateInput } from "./components/date-input";
+export { default as MaskedInput } from "./components/masked-input";
 
 //directives
 export { default as LazyLoadDirective } from "./directives/lazy-load";

--- a/src/stories/Calendar.stories.js
+++ b/src/stories/Calendar.stories.js
@@ -18,16 +18,7 @@ const Template = (args, { argTypes }) => {
     props: Object.keys(argTypes),
     data: () => ({
       date: [new Date("2022-01-01"), new Date("2022-01-05")],
-      value1: null,
-      choices: [
-        {
-          value: true,
-          label:
-            "Enabled asdfadsfadsfa qewrfqsdafsf asdfadsfadsfa qewrfqsdafsf asdfadsfadsfa qewrfqsdafsf",
-          subLabel: "hey"
-        },
-        { value: false, label: "Disabled" }
-      ]
+      value1: null
     }),
     components: { Calendar, Theme, Select },
     template: `<Theme :dark-mode="darkMode">

--- a/src/stories/Calendar.stories.js
+++ b/src/stories/Calendar.stories.js
@@ -17,14 +17,13 @@ const Template = (args, { argTypes }) => {
   return {
     props: Object.keys(argTypes),
     data: () => ({
-      date: [new Date("2022-01-01"), new Date("2022-01-05")],
-      value1: null
+      date: args.dateValue
     }),
     components: { Calendar, Theme, Select },
     template: `<Theme :dark-mode="darkMode">
         <div class="flex items-center justify-center flex-col">
-          {{date}}
-            <Calendar v-bind="$props" v-model="date" />
+          {{ date }}
+          <Calendar v-bind="$props" v-model="date" />
         </div>
     </Theme>`
   };
@@ -32,12 +31,14 @@ const Template = (args, { argTypes }) => {
 
 export const Normal = Template.bind({});
 Normal.args = {
-  range: false
+  range: false,
+  dateValue: [new Date("2022-01-01")]
 };
 
 export const Range = Template.bind({});
 Range.args = {
-  range: true
+  range: true,
+  dateValue: [new Date("2022-01-01"), new Date("2022-01-15")]
 };
 
 export const Disabled = Template.bind({});

--- a/src/stories/Calendar.stories.js
+++ b/src/stories/Calendar.stories.js
@@ -17,7 +17,7 @@ const Template = (args, { argTypes }) => {
   return {
     props: Object.keys(argTypes),
     data: () => ({
-      date: [new Date("2021-01-01"), new Date("2022-01-05")],
+      date: [new Date("2022-01-01"), new Date("2022-01-05")],
       value1: null,
       choices: [
         {
@@ -31,9 +31,9 @@ const Template = (args, { argTypes }) => {
     }),
     components: { Calendar, Theme, Select },
     template: `<Theme :dark-mode="darkMode">
-        <div class="flex items-center justify-center">
+        <div class="flex items-center justify-center flex-col">
+          {{date}}
             <Calendar v-bind="$props" v-model="date" />
-            <Select :options="choices" v-bind="$props" v-model="value1" />
         </div>
     </Theme>`
   };

--- a/src/stories/DateInput.stories.js
+++ b/src/stories/DateInput.stories.js
@@ -17,7 +17,7 @@ const Template = (args, { argTypes }) => {
   return {
     props: Object.keys(argTypes),
     data: () => ({
-      val1: new Date(),
+      val1: new Date("2022-01-01T00:00:00"),
       val2: "",
       val3: "",
       val4: ""

--- a/src/stories/DateInput.stories.js
+++ b/src/stories/DateInput.stories.js
@@ -1,0 +1,87 @@
+import Theme from "../components/theme/Theme.vue";
+import DateInput from "../components/date-input/DateInput.vue";
+import "../assets/styles/index.scss";
+
+export default {
+  title: "Form/DateInput",
+  component: DateInput,
+  argTypes: {
+    placeholder: { control: { type: "text" } },
+    label: { control: { type: "text" } },
+    disabled: { control: { type: "boolean" } },
+    darkMode: { control: { type: "boolean" } }
+  }
+};
+
+const Template = (args, { argTypes }) => {
+  return {
+    props: Object.keys(argTypes),
+    data: () => ({
+      val1: new Date(),
+      val2: "",
+      val3: "",
+      val4: ""
+    }),
+    components: { DateInput, Theme },
+    template: `<Theme :dark-mode="darkMode">
+      <div class="grid grid-cols-1 gap-4">
+        <DateInput
+          class="max-w-xs"
+          v-bind="$props"
+          label="MM / YYYY"
+          formatString="MM / yyyy"
+          mask="## / ####"
+          :initialValue="val1"
+        />
+        <DateInput
+          class="max-w-xs"
+          v-bind="$props"
+          formatString="dd / MM / yyyy"
+          mask="## / ## / ####"
+          label="DD / MM / YYYY"
+          v-model="val2"
+        />
+        <DateInput
+          class="max-w-xs"
+          v-bind="$props"
+          formatString="dd-MM-yyyy"
+          mask="##-##-####"
+          label="DD-MM-YYYY"
+          v-model="val3"
+        />
+        <DateInput
+          class="max-w-xs"
+          v-bind="$props"
+          formatString="dd.MM.yyyy"
+          mask="##.##.####"
+          label="DD.MM.YYYY"
+          v-model="val4"
+        />
+
+      </div>
+    </Theme>`
+  };
+};
+
+export const Label = Template.bind({});
+Label.args = {
+  placeholder: "Label"
+};
+
+export const Placeholder = Template.bind({});
+Placeholder.args = {
+  placeholder: "Placeholder"
+};
+
+export const LabelAndPlaceholder = Template.bind({});
+LabelAndPlaceholder.args = {
+  label: "Label",
+  placeholder: "Placeholder"
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  label: "Label",
+  placeholder: "Placeholder",
+  disabled: true
+};

--- a/src/stories/DateInput.stories.js
+++ b/src/stories/DateInput.stories.js
@@ -22,17 +22,25 @@ const Template = (args, { argTypes }) => {
       val3: "",
       val4: ""
     }),
+    methods: {
+      onInput(e) {
+        console.log(e);
+        console.log("did output");
+      }
+    },
     components: { DateInput, Theme },
     template: `<Theme :dark-mode="darkMode">
       <div class="grid grid-cols-1 gap-4">
+        {{val1}}
         <DateInput
           class="max-w-xs"
           v-bind="$props"
           label="MM / YYYY"
           formatString="MM / yyyy"
           mask="## / ####"
-          :initialValue="val1"
+          v-model="val1"
         />
+        {{val2}}
         <DateInput
           class="max-w-xs"
           v-bind="$props"
@@ -41,6 +49,7 @@ const Template = (args, { argTypes }) => {
           label="DD / MM / YYYY"
           v-model="val2"
         />
+        {{val3}}
         <DateInput
           class="max-w-xs"
           v-bind="$props"
@@ -48,7 +57,9 @@ const Template = (args, { argTypes }) => {
           mask="##-##-####"
           label="DD-MM-YYYY"
           v-model="val3"
+          @input="onInput"
         />
+        {{val4}}
         <DateInput
           class="max-w-xs"
           v-bind="$props"

--- a/src/stories/MaskedInput.stories.js
+++ b/src/stories/MaskedInput.stories.js
@@ -1,0 +1,98 @@
+import Theme from "../components/theme/Theme.vue";
+import MaskedInput from "../components/masked-input/MaskedInput.vue";
+import Button from "../components/button/Button.vue";
+import "../assets/styles/index.scss";
+import { icons } from "./utils";
+import "./storybook.css";
+import { validationMixin } from "vuelidate";
+
+export default {
+  title: "Form/MaskedInput",
+  component: MaskedInput,
+  argTypes: {
+    placeholder: { control: { type: "text" } },
+    label: { control: { type: "text" } },
+    prefix: { control: { type: "text" } },
+    suffix: { control: { type: "text" } },
+    icon: { control: { type: "select", options: icons } },
+    type: {
+      control: {
+        type: "select",
+        options: ["text", "email", "password", "number"]
+      }
+    },
+    hotkey: { control: { type: "object" } },
+    disabled: { control: { type: "boolean" } },
+    darkMode: { control: { type: "boolean" } }
+  }
+};
+
+const Template = (args, { argTypes }) => {
+  return {
+    props: Object.keys(argTypes),
+    components: { MaskedInput, Button, Theme },
+    mixins: [validationMixin],
+    data() {
+      return {
+        input1: null,
+        input2: "",
+        input3: "",
+        input4: "",
+        input5: ""
+      };
+    },
+    methods: {
+      submit() {
+        this.$v.$touch();
+      }
+    },
+    template: `<Theme :dark-mode="darkMode">
+      <div class="grid grid-cols-1 gap-2 content-start max-w-lg">
+        <MaskedInput 
+          v-model="input1"
+          v-bind="$props"
+        />
+      </div>
+    </Theme>`
+  };
+};
+
+export const Date = Template.bind({});
+Date.args = {
+  label: "DD / MM / YYYY",
+  maskOptions: {
+    mask: "`00` {/} `00` {/} `0000`",
+    placeholderChar: " ",
+    overwrite: true,
+    lazy: true
+  }
+};
+
+export const Currency = Template.bind({});
+Currency.args = {
+  placeholder: "Amount",
+  prefix: "€",
+  maskOptions: {
+    mask: "num",
+    blocks: {
+      num: {
+        mask: Number,
+        thousandsSeparator: " "
+      }
+    },
+    placeholderChar: " ",
+    overwrite: true,
+    lazy: true
+  }
+};
+
+export const CreditCard = Template.bind({});
+CreditCard.args = {
+  placeholder: "Card number",
+  maskOptions: {
+    mask: "`0000` `0000` `0000` `0000`",
+    placeholderChar: " ",
+    overwrite: true,
+    lazy: true
+  }
+};

--- a/tests/storyshots/__snapshots__/index.test.js.snap
+++ b/tests/storyshots/__snapshots__/index.test.js.snap
@@ -9754,8 +9754,14 @@ exports[`Storyshots Form/Calendar Disabled 1`] = `
   class="theme antialiased font-body text-font-primary bg-body theme-light"
 >
   <div
-    class="flex items-center justify-center"
+    class="flex items-center justify-center flex-col"
   >
+    
+          [
+  "2022-01-01T00:00:00.000Z",
+  "2022-01-05T00:00:00.000Z"
+]
+            
     <div
       class="c-form-control relative text-14 select-none font-semibold c-calendar font-semibold text-14 readonly disabled skeleton has-error-message has-date"
       disabled="disabled"
@@ -9785,6 +9791,50 @@ exports[`Storyshots Form/Calendar Disabled 1`] = `
           style="left: 0px;"
         >
           <div
+            class="flex justify-between items-center px-4 py-4 border-b border-alt2"
+          >
+            <div
+              class="c-form-control relative text-14 select-none font-semibold c-input c-date-input w-full skeleton has-error-message label-inside label-always-visible has-value"
+              formatstring="dd / MM / yyyy"
+              mask="## / ## / ####"
+              maxlength="14"
+            >
+              <div
+                class="flex box"
+              >
+                <!---->
+                 
+                <!---->
+                 
+                <div
+                  class="flex relative flex-1"
+                >
+                  <!---->
+                   
+                  <input
+                    data-mask="## / ## / ####"
+                    data-mask-inited="true"
+                    maxlength="14"
+                    placeholder="DD / MM / YYYY"
+                  />
+                   
+                  <!---->
+                </div>
+                 
+                <!---->
+                 
+                <!---->
+              </div>
+               
+              <!---->
+               
+              <!---->
+            </div>
+             
+            <!---->
+          </div>
+           
+          <div
             class="flex px-6 py-4"
           >
             <div
@@ -10394,40 +10444,6 @@ exports[`Storyshots Form/Calendar Disabled 1`] = `
        
       <!---->
     </div>
-     
-    <div
-      class="c-form-control relative text-14 select-none font-semibold c-select font-semibold text-font-primary readonly disabled skeleton has-error-message"
-      disabled="disabled"
-      options="[object Object],[object Object]"
-    >
-      <select
-        class="opacity-0 absolute w-0 h-0"
-      />
-       
-      <div
-        class="box selected cursor-pointer rounded-sm flex items-stretch justify-between"
-      >
-        <div
-          class="divider-r flex flex-col h-full justify-center overflow-hidden flex-1 px-3"
-        >
-          <!---->
-           
-          <!---->
-           
-          <!---->
-        </div>
-         
-        <div
-          class="suffix icon icon-chevron-down"
-        />
-      </div>
-       
-      <!---->
-       
-      <!---->
-       
-      <!---->
-    </div>
   </div>
 </main>
 `;
@@ -10437,8 +10453,14 @@ exports[`Storyshots Form/Calendar Normal 1`] = `
   class="theme antialiased font-body text-font-primary bg-body theme-light"
 >
   <div
-    class="flex items-center justify-center"
+    class="flex items-center justify-center flex-col"
   >
+    
+          [
+  "2022-01-01T00:00:00.000Z",
+  "2022-01-05T00:00:00.000Z"
+]
+            
     <div
       class="c-form-control relative text-14 select-none font-semibold c-calendar font-semibold text-14 skeleton has-error-message has-date"
       safespace="16"
@@ -10467,745 +10489,49 @@ exports[`Storyshots Form/Calendar Normal 1`] = `
           style="left: 0px;"
         >
           <div
-            class="flex px-6 py-4"
+            class="flex justify-between items-center px-4 py-4 border-b border-alt2"
           >
             <div
-              class="text-center calendar whitespace-no-wrap mr-6 last:mr-0"
+              class="c-form-control relative text-14 select-none font-semibold c-input c-date-input w-full skeleton has-error-message label-inside label-always-visible has-value"
+              formatstring="dd / MM / yyyy"
+              mask="## / ## / ####"
+              maxlength="14"
             >
               <div
-                class="flex relative mb-6"
+                class="flex box"
               >
-                <div
-                  class="cursor-pointer ml-2 icon icon-arrow-left"
-                />
+                <!---->
                  
-                <p
-                  class="month absolute transform -translate-x-1/2 left-1/2 top-1/2 -translate-y-1/2"
+                <!---->
+                 
+                <div
+                  class="flex relative flex-1"
                 >
-                  
-              January 2022
-            
-                </p>
+                  <!---->
+                   
+                  <input
+                    data-mask="## / ## / ####"
+                    data-mask-inited="true"
+                    maxlength="14"
+                    placeholder="DD / MM / YYYY"
+                  />
+                   
+                  <!---->
+                </div>
+                 
+                <!---->
                  
                 <!---->
               </div>
                
-              <ul
-                class="days flex text-font-alt3"
-              >
-                <li>
-                  
-              Mo
-            
-                </li>
-                 
-                <li>
-                  
-              Tu
-            
-                </li>
-                 
-                <li>
-                  
-              We
-            
-                </li>
-                 
-                <li>
-                  
-              Th
-            
-                </li>
-                 
-                <li>
-                  
-              Fr
-            
-                </li>
-                 
-                <li>
-                  
-              Sa
-            
-                </li>
-                 
-                <li>
-                  
-              Su
-            
-                </li>
-              </ul>
-               
-              <ul
-                class="dates flex flex-wrap"
-              >
-                <li
-                  class="date cursor-pointer empty"
-                >
-                  
-              
-            
-                </li>
-                <li
-                  class="date cursor-pointer empty"
-                >
-                  
-              
-            
-                </li>
-                <li
-                  class="date cursor-pointer empty"
-                >
-                  
-              
-            
-                </li>
-                <li
-                  class="date cursor-pointer empty"
-                >
-                  
-              
-            
-                </li>
-                <li
-                  class="date cursor-pointer empty"
-                >
-                  
-              
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              1
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              2
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              3
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              4
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              5
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              6
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              7
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              8
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              9
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              10
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              11
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              12
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              13
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              14
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              15
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              16
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              17
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              18
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              19
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              20
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              21
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              22
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              23
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              24
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              25
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              26
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              27
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              28
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              29
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              30
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              31
-            
-                </li>
-              </ul>
-            </div>
-            <div
-              class="text-center calendar whitespace-no-wrap mr-6 last:mr-0"
-            >
-              <div
-                class="flex relative mb-6"
-              >
-                <!---->
-                 
-                <p
-                  class="month absolute transform -translate-x-1/2 left-1/2 top-1/2 -translate-y-1/2"
-                >
-                  
-              February 2022
-            
-                </p>
-                 
-                <div
-                  class="cursor-pointer ml-auto mr-2 icon icon-arrow-right"
-                />
-              </div>
-               
-              <ul
-                class="days flex text-font-alt3"
-              >
-                <li>
-                  
-              Mo
-            
-                </li>
-                 
-                <li>
-                  
-              Tu
-            
-                </li>
-                 
-                <li>
-                  
-              We
-            
-                </li>
-                 
-                <li>
-                  
-              Th
-            
-                </li>
-                 
-                <li>
-                  
-              Fr
-            
-                </li>
-                 
-                <li>
-                  
-              Sa
-            
-                </li>
-                 
-                <li>
-                  
-              Su
-            
-                </li>
-              </ul>
-               
-              <ul
-                class="dates flex flex-wrap"
-              >
-                <li
-                  class="date cursor-pointer empty"
-                >
-                  
-              
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              1
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              2
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              3
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              4
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              5
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              6
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              7
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              8
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              9
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              10
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              11
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              12
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              13
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              14
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              15
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              16
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              17
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              18
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              19
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              20
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              21
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              22
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              23
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              24
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              25
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              26
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              27
-            
-                </li>
-                <li
-                  class="date cursor-pointer"
-                >
-                  
-              28
-            
-                </li>
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-       
-      <!---->
-       
-      <!---->
-    </div>
-     
-    <div
-      class="c-form-control relative text-14 select-none font-semibold c-select font-semibold text-font-primary skeleton has-error-message"
-      options="[object Object],[object Object]"
-    >
-      <select
-        class="opacity-0 absolute w-0 h-0"
-      />
-       
-      <div
-        class="box selected cursor-pointer rounded-sm flex items-stretch justify-between"
-      >
-        <div
-          class="divider-r flex flex-col h-full justify-center overflow-hidden flex-1 px-3"
-        >
-          <!---->
-           
-          <!---->
-           
-          <!---->
-        </div>
-         
-        <div
-          class="suffix icon icon-chevron-down"
-        />
-      </div>
-       
-      <div
-        class="options min-w-full p-1 origin-top z-50 absolute rounded-sm top-full mt-1 bg-base border border-alt2 shadow-overlay"
-        style="display: none;"
-      >
-        <ul
-          class="max-h-80 overflow-y-scroll scrollbar whitespace-no-wrap"
-        >
-          <li
-            class="option py-1 rounded-sm flex items-center px-2 cursor-pointer active"
-          >
-            <!---->
-             
-            <div
-              class="flex c-label truncate cursor-pointer flex-col"
-            >
-              <strong
-                class="label text-font-primary"
-              >
-                Enabled asdfadsfadsfa qewrfqsdafsf asdfadsfadsfa qewrfqsdafsf asdfadsfadsfa qewrfqsdafsf
-              </strong>
-               
-              <span
-                class="font-normal sub-label text-font-alt3"
-              >
-                hey
-              </span>
-            </div>
-          </li>
-          <li
-            class="option py-1 rounded-sm flex items-center px-2 cursor-pointer"
-          >
-            <!---->
-             
-            <div
-              class="flex c-label truncate cursor-pointer flex-col"
-            >
-              <strong
-                class="label text-font-primary"
-              >
-                Disabled
-              </strong>
+              <!---->
                
               <!---->
             </div>
-          </li>
-        </ul>
-      </div>
-       
-      <!---->
-       
-      <!---->
-    </div>
-  </div>
-</main>
-`;
-
-exports[`Storyshots Form/Calendar Range 1`] = `
-<main
-  class="theme antialiased font-body text-font-primary bg-body theme-light"
->
-  <div
-    class="flex items-center justify-center"
-  >
-    <div
-      class="c-form-control relative text-14 select-none font-semibold c-calendar font-semibold text-14 skeleton has-error-message has-date is-range"
-      range="true"
-      safespace="16"
-    >
-      <div
-        class="flex box selected sm items-center relative z-20 cursor-pointer"
-      >
-        <div
-          class="value h-8 px-3 flex items-center flex-1 divider"
-        >
-          <p>
-            
-        Jan 01, 2021
-      
-          </p>
+             
+            <!---->
+          </div>
            
-          <span
-            class="mx-2 icon icon-arrow-right"
-          />
-           
-          <p>
-            
-          Jan 05, 2022
-        
-          </p>
-        </div>
-         
-        <div
-          class="suffix icon icon-chevron-down"
-        />
-      </div>
-       
-      <div
-        class="date-picker-wrapper left-1/2 transform -translate-x-1/2 absolute top-full"
-      >
-        <div
-          class="date-picker relative border z-40 rounded border-alt2 bg-base mt-1 shadow-overlay"
-          style="left: 0px;"
-        >
           <div
             class="flex px-6 py-4"
           >
@@ -11816,27 +11142,49 @@ exports[`Storyshots Form/Calendar Range 1`] = `
        
       <!---->
     </div>
-     
+  </div>
+</main>
+`;
+
+exports[`Storyshots Form/Calendar Range 1`] = `
+<main
+  class="theme antialiased font-body text-font-primary bg-body theme-light"
+>
+  <div
+    class="flex items-center justify-center flex-col"
+  >
+    
+          [
+  "2022-01-01T00:00:00.000Z",
+  "2022-01-05T00:00:00.000Z"
+]
+            
     <div
-      class="c-form-control relative text-14 select-none font-semibold c-select font-semibold text-font-primary skeleton has-error-message"
-      options="[object Object],[object Object]"
+      class="c-form-control relative text-14 select-none font-semibold c-calendar font-semibold text-14 skeleton has-error-message has-date is-range"
       range="true"
+      safespace="16"
     >
-      <select
-        class="opacity-0 absolute w-0 h-0"
-      />
-       
       <div
-        class="box selected cursor-pointer rounded-sm flex items-stretch justify-between"
+        class="flex box selected sm items-center relative z-20 cursor-pointer"
       >
         <div
-          class="divider-r flex flex-col h-full justify-center overflow-hidden flex-1 px-3"
+          class="value h-8 px-3 flex items-center flex-1 divider"
         >
-          <!---->
+          <p>
+            
+        Jan 01, 2022
+      
+          </p>
            
-          <!---->
+          <span
+            class="mx-2 icon icon-arrow-right"
+          />
            
-          <!---->
+          <p>
+            
+          Jan 05, 2022
+        
+          </p>
         </div>
          
         <div
@@ -11845,51 +11193,700 @@ exports[`Storyshots Form/Calendar Range 1`] = `
       </div>
        
       <div
-        class="options min-w-full p-1 origin-top z-50 absolute rounded-sm top-full mt-1 bg-base border border-alt2 shadow-overlay"
-        style="display: none;"
+        class="date-picker-wrapper left-1/2 transform -translate-x-1/2 absolute top-full"
       >
-        <ul
-          class="max-h-80 overflow-y-scroll scrollbar whitespace-no-wrap"
+        <div
+          class="date-picker relative border z-40 rounded border-alt2 bg-base mt-1 shadow-overlay"
+          style="left: 0px;"
         >
-          <li
-            class="option py-1 rounded-sm flex items-center px-2 cursor-pointer active"
+          <div
+            class="flex justify-between items-center px-4 py-4 border-b border-alt2"
           >
-            <!---->
-             
             <div
-              class="flex c-label truncate cursor-pointer flex-col"
+              class="c-form-control relative text-14 select-none font-semibold c-input c-date-input w-full skeleton has-error-message label-inside label-always-visible has-value"
+              formatstring="dd / MM / yyyy"
+              mask="## / ## / ####"
+              maxlength="14"
             >
-              <strong
-                class="label text-font-primary"
+              <div
+                class="flex box"
               >
-                Enabled asdfadsfadsfa qewrfqsdafsf asdfadsfadsfa qewrfqsdafsf asdfadsfadsfa qewrfqsdafsf
-              </strong>
+                <!---->
+                 
+                <!---->
+                 
+                <div
+                  class="flex relative flex-1"
+                >
+                  <!---->
+                   
+                  <input
+                    data-mask="## / ## / ####"
+                    data-mask-inited="true"
+                    maxlength="14"
+                    placeholder="DD / MM / YYYY"
+                  />
+                   
+                  <!---->
+                </div>
+                 
+                <!---->
+                 
+                <!---->
+              </div>
                
-              <span
-                class="font-normal sub-label text-font-alt3"
-              >
-                hey
-              </span>
-            </div>
-          </li>
-          <li
-            class="option py-1 rounded-sm flex items-center px-2 cursor-pointer"
-          >
-            <!---->
-             
-            <div
-              class="flex c-label truncate cursor-pointer flex-col"
-            >
-              <strong
-                class="label text-font-primary"
-              >
-                Disabled
-              </strong>
+              <!---->
                
               <!---->
             </div>
-          </li>
-        </ul>
+             
+            <div
+              class="mx-2 icon icon-arrow-right"
+            />
+             
+            <div
+              class="c-form-control relative text-14 select-none font-semibold c-input c-date-input w-full skeleton has-error-message label-inside label-always-visible has-value"
+              formatstring="dd / MM / yyyy"
+              mask="## / ## / ####"
+              maxlength="14"
+            >
+              <div
+                class="flex box"
+              >
+                <!---->
+                 
+                <!---->
+                 
+                <div
+                  class="flex relative flex-1"
+                >
+                  <!---->
+                   
+                  <input
+                    data-mask="## / ## / ####"
+                    data-mask-inited="true"
+                    maxlength="14"
+                    placeholder="DD / MM / YYYY"
+                  />
+                   
+                  <!---->
+                </div>
+                 
+                <!---->
+                 
+                <!---->
+              </div>
+               
+              <!---->
+               
+              <!---->
+            </div>
+          </div>
+           
+          <div
+            class="flex px-6 py-4"
+          >
+            <div
+              class="text-center calendar whitespace-no-wrap mr-6 last:mr-0"
+            >
+              <div
+                class="flex relative mb-6"
+              >
+                <div
+                  class="cursor-pointer ml-2 icon icon-arrow-left"
+                />
+                 
+                <p
+                  class="month absolute transform -translate-x-1/2 left-1/2 top-1/2 -translate-y-1/2"
+                >
+                  
+              January 2022
+            
+                </p>
+                 
+                <!---->
+              </div>
+               
+              <ul
+                class="days flex text-font-alt3"
+              >
+                <li>
+                  
+              Mo
+            
+                </li>
+                 
+                <li>
+                  
+              Tu
+            
+                </li>
+                 
+                <li>
+                  
+              We
+            
+                </li>
+                 
+                <li>
+                  
+              Th
+            
+                </li>
+                 
+                <li>
+                  
+              Fr
+            
+                </li>
+                 
+                <li>
+                  
+              Sa
+            
+                </li>
+                 
+                <li>
+                  
+              Su
+            
+                </li>
+              </ul>
+               
+              <ul
+                class="dates flex flex-wrap"
+              >
+                <li
+                  class="date cursor-pointer empty"
+                >
+                  
+              
+            
+                </li>
+                <li
+                  class="date cursor-pointer empty"
+                >
+                  
+              
+            
+                </li>
+                <li
+                  class="date cursor-pointer empty"
+                >
+                  
+              
+            
+                </li>
+                <li
+                  class="date cursor-pointer empty"
+                >
+                  
+              
+            
+                </li>
+                <li
+                  class="date cursor-pointer empty"
+                >
+                  
+              
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              1
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              2
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              3
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              4
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              5
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              6
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              7
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              8
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              9
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              10
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              11
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              12
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              13
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              14
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              15
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              16
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              17
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              18
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              19
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              20
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              21
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              22
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              23
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              24
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              25
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              26
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              27
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              28
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              29
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              30
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              31
+            
+                </li>
+              </ul>
+            </div>
+            <div
+              class="text-center calendar whitespace-no-wrap mr-6 last:mr-0"
+            >
+              <div
+                class="flex relative mb-6"
+              >
+                <!---->
+                 
+                <p
+                  class="month absolute transform -translate-x-1/2 left-1/2 top-1/2 -translate-y-1/2"
+                >
+                  
+              February 2022
+            
+                </p>
+                 
+                <div
+                  class="cursor-pointer ml-auto mr-2 icon icon-arrow-right"
+                />
+              </div>
+               
+              <ul
+                class="days flex text-font-alt3"
+              >
+                <li>
+                  
+              Mo
+            
+                </li>
+                 
+                <li>
+                  
+              Tu
+            
+                </li>
+                 
+                <li>
+                  
+              We
+            
+                </li>
+                 
+                <li>
+                  
+              Th
+            
+                </li>
+                 
+                <li>
+                  
+              Fr
+            
+                </li>
+                 
+                <li>
+                  
+              Sa
+            
+                </li>
+                 
+                <li>
+                  
+              Su
+            
+                </li>
+              </ul>
+               
+              <ul
+                class="dates flex flex-wrap"
+              >
+                <li
+                  class="date cursor-pointer empty"
+                >
+                  
+              
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              1
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              2
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              3
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              4
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              5
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              6
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              7
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              8
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              9
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              10
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              11
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              12
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              13
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              14
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              15
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              16
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              17
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              18
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              19
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              20
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              21
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              22
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              23
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              24
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              25
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              26
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              27
+            
+                </li>
+                <li
+                  class="date cursor-pointer"
+                >
+                  
+              28
+            
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
       </div>
        
       <!---->
@@ -15445,6 +15442,762 @@ exports[`Storyshots Form/CheckboxTree Toggle All 1`] = `
           </ul>
         </li>
       </ul>
+    </div>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Form/DateInput Disabled 1`] = `
+<main
+  class="theme antialiased font-body text-font-primary bg-body theme-light"
+>
+  <div
+    class="grid grid-cols-1 gap-4"
+  >
+    
+        Sat Jan 01 2022 00:00:00 GMT+0100 (Central European Standard Time)
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs readonly disabled skeleton has-error-message label-inside label-always-visible has-value has-label"
+      disabled="disabled"
+      formatstring="MM / yyyy"
+      mask="## / ####"
+      maxlength="9"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            MM / YYYY
+          </label>
+           
+          <input
+            data-mask="## / ####"
+            data-mask-inited="true"
+            maxlength="9"
+            placeholder="Placeholder"
+            readonly="readonly"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs readonly disabled skeleton has-error-message label-inside label-always-visible has-value has-label"
+      disabled="disabled"
+      formatstring="dd / MM / yyyy"
+      mask="## / ## / ####"
+      maxlength="14"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD / MM / YYYY
+          </label>
+           
+          <input
+            data-mask="## / ## / ####"
+            data-mask-inited="true"
+            maxlength="14"
+            placeholder="Placeholder"
+            readonly="readonly"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs readonly disabled skeleton has-error-message label-inside label-always-visible has-value has-label"
+      disabled="disabled"
+      formatstring="dd-MM-yyyy"
+      mask="##-##-####"
+      maxlength="10"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD-MM-YYYY
+          </label>
+           
+          <input
+            data-mask="##-##-####"
+            data-mask-inited="true"
+            maxlength="10"
+            placeholder="Placeholder"
+            readonly="readonly"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs readonly disabled skeleton has-error-message label-inside label-always-visible has-value has-label"
+      disabled="disabled"
+      formatstring="dd.MM.yyyy"
+      mask="##.##.####"
+      maxlength="10"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD.MM.YYYY
+          </label>
+           
+          <input
+            data-mask="##.##.####"
+            data-mask-inited="true"
+            maxlength="10"
+            placeholder="Placeholder"
+            readonly="readonly"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Form/DateInput Label 1`] = `
+<main
+  class="theme antialiased font-body text-font-primary bg-body theme-light"
+>
+  <div
+    class="grid grid-cols-1 gap-4"
+  >
+    
+        Sat Jan 01 2022 00:00:00 GMT+0100 (Central European Standard Time)
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="MM / yyyy"
+      mask="## / ####"
+      maxlength="9"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            MM / YYYY
+          </label>
+           
+          <input
+            data-mask="## / ####"
+            data-mask-inited="true"
+            maxlength="9"
+            placeholder="Label"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="dd / MM / yyyy"
+      mask="## / ## / ####"
+      maxlength="14"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD / MM / YYYY
+          </label>
+           
+          <input
+            data-mask="## / ## / ####"
+            data-mask-inited="true"
+            maxlength="14"
+            placeholder="Label"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="dd-MM-yyyy"
+      mask="##-##-####"
+      maxlength="10"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD-MM-YYYY
+          </label>
+           
+          <input
+            data-mask="##-##-####"
+            data-mask-inited="true"
+            maxlength="10"
+            placeholder="Label"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="dd.MM.yyyy"
+      mask="##.##.####"
+      maxlength="10"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD.MM.YYYY
+          </label>
+           
+          <input
+            data-mask="##.##.####"
+            data-mask-inited="true"
+            maxlength="10"
+            placeholder="Label"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Form/DateInput Label And Placeholder 1`] = `
+<main
+  class="theme antialiased font-body text-font-primary bg-body theme-light"
+>
+  <div
+    class="grid grid-cols-1 gap-4"
+  >
+    
+        Sat Jan 01 2022 00:00:00 GMT+0100 (Central European Standard Time)
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="MM / yyyy"
+      mask="## / ####"
+      maxlength="9"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            MM / YYYY
+          </label>
+           
+          <input
+            data-mask="## / ####"
+            data-mask-inited="true"
+            maxlength="9"
+            placeholder="Placeholder"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="dd / MM / yyyy"
+      mask="## / ## / ####"
+      maxlength="14"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD / MM / YYYY
+          </label>
+           
+          <input
+            data-mask="## / ## / ####"
+            data-mask-inited="true"
+            maxlength="14"
+            placeholder="Placeholder"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="dd-MM-yyyy"
+      mask="##-##-####"
+      maxlength="10"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD-MM-YYYY
+          </label>
+           
+          <input
+            data-mask="##-##-####"
+            data-mask-inited="true"
+            maxlength="10"
+            placeholder="Placeholder"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="dd.MM.yyyy"
+      mask="##.##.####"
+      maxlength="10"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD.MM.YYYY
+          </label>
+           
+          <input
+            data-mask="##.##.####"
+            data-mask-inited="true"
+            maxlength="10"
+            placeholder="Placeholder"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+  </div>
+</main>
+`;
+
+exports[`Storyshots Form/DateInput Placeholder 1`] = `
+<main
+  class="theme antialiased font-body text-font-primary bg-body theme-light"
+>
+  <div
+    class="grid grid-cols-1 gap-4"
+  >
+    
+        Sat Jan 01 2022 00:00:00 GMT+0100 (Central European Standard Time)
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="MM / yyyy"
+      mask="## / ####"
+      maxlength="9"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            MM / YYYY
+          </label>
+           
+          <input
+            data-mask="## / ####"
+            data-mask-inited="true"
+            maxlength="9"
+            placeholder="Placeholder"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="dd / MM / yyyy"
+      mask="## / ## / ####"
+      maxlength="14"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD / MM / YYYY
+          </label>
+           
+          <input
+            data-mask="## / ## / ####"
+            data-mask-inited="true"
+            maxlength="14"
+            placeholder="Placeholder"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="dd-MM-yyyy"
+      mask="##-##-####"
+      maxlength="10"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD-MM-YYYY
+          </label>
+           
+          <input
+            data-mask="##-##-####"
+            data-mask-inited="true"
+            maxlength="10"
+            placeholder="Placeholder"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
+    </div>
+    
+        
+        
+    <div
+      class="c-form-control relative text-14 select-none font-semibold c-input c-date-input max-w-xs skeleton has-error-message label-inside label-always-visible has-value has-label"
+      formatstring="dd.MM.yyyy"
+      mask="##.##.####"
+      maxlength="10"
+    >
+      <div
+        class="flex box"
+      >
+        <!---->
+         
+        <!---->
+         
+        <div
+          class="flex relative flex-1"
+        >
+          <label
+            class="pointer-events-none"
+          >
+            DD.MM.YYYY
+          </label>
+           
+          <input
+            data-mask="##.##.####"
+            data-mask-inited="true"
+            maxlength="10"
+            placeholder="Placeholder"
+          />
+           
+          <!---->
+        </div>
+         
+        <!---->
+         
+        <!---->
+      </div>
+       
+      <!---->
+       
+      <!---->
     </div>
   </div>
 </main>


### PR DESCRIPTION
This adds masked inputs for the calendar.

I think there are some points regarding state management (as listed below) that can and should be resolved first, so a review would be appreciated!

<img width="575" alt="Chargetrip Calender component with two new input fields in which a start and end date can be  entered" src="https://user-images.githubusercontent.com/12190184/150175674-473bda24-80a1-4c92-a2d6-672177fbb9be.png">

**Some design questions / edge case  I'm not sure about yet:**

* If a `range` is selected and the user enters e.g. a `start date` that exceeds the current `end date` I swap the dates. I'm not sure if this is all that intuitive? Otherwise the input ends up in an invalid state, but not updating the date in that case can also be an option.

* While the input works inside of the `Calendar` or any other component with its own state, it doesn't work on its own as the `initialValue` is reset, see the story for an example.

* Perhaps _in the future_  the underlying code for the current `DateInput` component can be abstracted to a `MaskedInput` component in case this needs to be applied to e.g. a phone number or other input that requires a specific format?
