### PR TITLE
Fix calendar tests

### DIFF
--- a/src/stories/Calendar.stories.js
+++ b/src/stories/Calendar.stories.js
@@ -15,7 +15,8 @@ export default {
 
 const Template = (args, { argTypes }) => {
   return {
-    props: Object.keys(argTypes),
+    // Filter the non-deterministic `dateInput` as it will make snapshots fail.
+    props: Object.keys(argTypes).filter(p => p !== "dateInput"),
     data: () => ({
       date: args.dateInput
     }),

--- a/tests/storyshots/__snapshots__/index.test.js.snap
+++ b/tests/storyshots/__snapshots__/index.test.js.snap
@@ -10525,7 +10525,6 @@ exports[`Storyshots Form/Calendar Normal 1`] = `
             
     <div
       class="c-form-control relative text-14 select-none font-semibold c-calendar font-semibold text-14 skeleton has-error-message has-date"
-      dateinput="Sat Jan 01 2022 01:00:00 GMT+0100 (Central European Standard Time)"
       safespace="16"
     >
       <div
@@ -11313,7 +11312,6 @@ exports[`Storyshots Form/Calendar Range 1`] = `
             
     <div
       class="c-form-control relative text-14 select-none font-semibold c-calendar font-semibold text-14 skeleton has-error-message has-date is-range"
-      dateinput="Sat Jan 01 2022 01:00:00 GMT+0100 (Central European Standard Time),Sat Jan 15 2022 01:00:00 GMT+0100 (Central European Standard Time)"
       range="true"
       safespace="16"
     >


### PR DESCRIPTION
This excludes the `dateInput` prop from the component, which caused snapshot tests to fail.