### PR TITLE
Feat: Add GitHub highlight styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chargetrip/internal-vue-components",
-  "version": "0.0.554",
+  "version": "0.0.555",
   "private": false,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/src/assets/styles/defaults.scss
+++ b/src/assets/styles/defaults.scss
@@ -76,17 +76,14 @@
 }
 
 
-// code highlights
+// Code highlighting based on GitHub's styles
 .theme-light {
-  /* http://jmblog.github.com/color-themes-for-google-code-highlightjs */
 
-  /* Tomorrow Comment */
   .hljs-comment,
   .hljs-quote {
-    color: #8e908c;
+    color: #6e7781;
   }
 
-  /* Tomorrow Red */
   .hljs-variable,
   .hljs-template-variable,
   .hljs-tag,
@@ -95,10 +92,9 @@
   .hljs-selector-class,
   .hljs-regexp,
   .hljs-deletion {
-    color: #c82829;
+    color: #953800;
   }
 
-  /* Tomorrow Orange */
   .hljs-number,
   .hljs-built_in,
   .hljs-builtin-name,
@@ -107,32 +103,28 @@
   .hljs-params,
   .hljs-meta,
   .hljs-link {
-    color: #f5871f;
+    color: #0550ae;
   }
 
-  /* Tomorrow Yellow */
   .hljs-attribute {
     color: #eab700;
   }
 
-  /* Tomorrow Green */
   .hljs-string,
   .hljs-symbol,
   .hljs-bullet,
   .hljs-addition {
-    color: #718c00;
+    color: #0a3069;
   }
 
-  /* Tomorrow Blue */
   .hljs-title,
   .hljs-section {
     color: #4271ae;
   }
 
-  /* Tomorrow Purple */
   .hljs-keyword,
   .hljs-selector-tag {
-    color: #8959a8;
+    color: #cf222e;
   }
 
   .hljs {
@@ -153,13 +145,11 @@
 }
 
 .theme-dark {
-  /* Tomorrow Comment */
   .hljs-comment,
   .hljs-quote {
-    color: #969896;
+    color: #8b949e;
   }
 
-  /* Tomorrow Red */
   .hljs-variable,
   .hljs-template-variable,
   .hljs-tag,
@@ -168,10 +158,9 @@
   .hljs-selector-class,
   .hljs-regexp,
   .hljs-deletion {
-    color: #cc6;
+    color: #ffa657;
   }
 
-  /* Tomorrow Orange */
   .hljs-number,
   .hljs-built_in,
   .hljs-builtin-name,
@@ -180,32 +169,28 @@
   .hljs-params,
   .hljs-meta,
   .hljs-link {
-    color: #de935f;
+    color: #79c0ff;
   }
 
-  /* Tomorrow Yellow */
   .hljs-attribute {
     color: #f0c674;
   }
 
-  /* Tomorrow Green */
   .hljs-string,
   .hljs-symbol,
   .hljs-bullet,
   .hljs-addition {
-    color: #b5bd68;
+    color: #a5d6ff;
   }
 
-  /* Tomorrow Blue */
   .hljs-title,
   .hljs-section {
     color: #81a2be;
   }
 
-  /* Tomorrow Purple */
   .hljs-keyword,
   .hljs-selector-tag {
-    color: #b294bb;
+    color: #ff7b72;
   }
 
   .hljs {

--- a/src/assets/styles/defaults.scss
+++ b/src/assets/styles/defaults.scss
@@ -80,7 +80,8 @@
 .theme-light {
 
   .hljs-comment,
-  .hljs-quote {
+  .hljs-quote,
+  .cmt-comment {
     color: #6e7781;
   }
 
@@ -102,7 +103,10 @@
   .hljs-type,
   .hljs-params,
   .hljs-meta,
-  .hljs-link {
+  .hljs-link,
+  .cmt-meta,
+  .cmt-propertyName,
+  .cmt-className {
     color: #0550ae;
   }
 
@@ -113,7 +117,8 @@
   .hljs-string,
   .hljs-symbol,
   .hljs-bullet,
-  .hljs-addition {
+  .hljs-addition,
+  .cmt-string {
     color: #0a3069;
   }
 
@@ -123,8 +128,13 @@
   }
 
   .hljs-keyword,
-  .hljs-selector-tag {
+  .hljs-selector-tag,
+  .cmt-keyword {
     color: #cf222e;
+  }
+
+  .cmt-typeName {
+    color: #116329;
   }
 
   .hljs {
@@ -146,7 +156,8 @@
 
 .theme-dark {
   .hljs-comment,
-  .hljs-quote {
+  .hljs-quote,
+  .cmt-comment {
     color: #8b949e;
   }
 
@@ -167,8 +178,9 @@
   .hljs-literal,
   .hljs-type,
   .hljs-params,
-  .hljs-meta,
-  .hljs-link {
+  .hljs-link,
+  .cmt-propertyName,
+  .cmt-className {
     color: #79c0ff;
   }
 
@@ -179,7 +191,10 @@
   .hljs-string,
   .hljs-symbol,
   .hljs-bullet,
-  .hljs-addition {
+  .hljs-addition,
+  .hljs-meta,
+  .cmt-string,
+  .cmt-meta {
     color: #a5d6ff;
   }
 
@@ -189,8 +204,13 @@
   }
 
   .hljs-keyword,
-  .hljs-selector-tag {
+  .hljs-selector-tag,
+  .cmt-keyword {
     color: #ff7b72;
+  }
+
+  .cmt-typeName {
+    color: #7ee787;
   }
 
   .hljs {

--- a/src/stories/CodeBlock.stories.js
+++ b/src/stories/CodeBlock.stories.js
@@ -122,9 +122,65 @@ const Template = (args, { argTypes }) => {
       }
     }),
     template: `<Theme :dark-mode="darkMode">
-    <CodeBlock lang="json" v-bind="$props" title="hey!">
-      keytool -list -v -keystore your_keystore_name -alias your_alias_name keytool -list -v -keystore your_keystore_name -alias your_alias_name keytool -list -v -keystore your_keystore_name -alias your_alias_name keytool -list -v -keystore your_keystore_name -alias your_alias_name
+    <CodeBlock lang="bash" v-bind="$props" title="Example command" class="mb-4">
+      keytool --list -v \\
+  --keystore your_keystore_name \\
+  --alias your_alias_name
     </CodeBlock>
+
+    <CodeBlock lang="bash" v-bind="$props" title="Example cURL" class="mb-4">
+curl -X POST \\
+-H "Content-Type: application/json" \\
+-H "x-client-id: 5c00b13d00b13d0000000000" \\
+-d 'query { }' \\
+http://api.chargetrip.io/graphql
+    </CodeBlock>
+
+    <CodeBlock lang="gql" v-bind="$props" title="Request (GraphQL)" class="mb-4">
+# Example query
+mutation addReview($stationId: String!, $carId: String) {
+  addReview(
+    review: {
+      stationId: $stationId
+      rating: 5
+      message: "My review message"
+      tags: { working: true, recommended: true }
+      locale: "en-US"
+      ev: $carId
+      plugType: CHADEMO
+    }
+  ) {
+    id,
+    createdAt,
+    rating,
+    ev {
+      make,
+      carModel,
+      edition
+    }
+    message,
+  }
+}
+    </CodeBlock>
+
+    <CodeBlock lang="json" v-bind="$props" title="Response (JSON)" class="mb-4">
+{
+  "data": {
+    "addReview": {
+      "id": "5c00b13d00b13d0000000000",
+      "createdAt": "2020-12-17T11:37:40Z",
+      "rating": 5,
+      "ev": {
+        "make": null,
+        "carModel": null,
+        "edition": null
+      },
+      "message": "My review message"
+    }
+  }
+}
+    </CodeBlock>
+
     <CodeBlock lang="json" v-bind="$props">
       {{ json }}
     </CodeBlock>

--- a/tests/storyshots/__snapshots__/index.test.js.snap
+++ b/tests/storyshots/__snapshots__/index.test.js.snap
@@ -1821,7 +1821,7 @@ exports[`Storyshots Components/CodeBlock Default 1`] = `
   class="theme antialiased font-body text-font-primary bg-body theme-light"
 >
   <div
-    class="code-block text-font-primary rounded border border-alt text-14 group bg-base is-single-line"
+    class="code-block text-font-primary rounded border border-alt text-14 group mb-4 bg-base"
   >
     <header
       class="flex h-10 px-6 font-semibold items-center border-b border-alt text-font-alt2 relative z-10"
@@ -1831,7 +1831,7 @@ exports[`Storyshots Components/CodeBlock Default 1`] = `
       >
         <!---->
         
-      hey!
+      Example command
     
       </div>
        
@@ -1854,21 +1854,482 @@ exports[`Storyshots Components/CodeBlock Default 1`] = `
       <div
         class="relative flex"
       >
-        <div
-          class="absolute right-0 flex items-center top-0 h-full z-10 opacity-0 group-hover:opacity-100"
-        >
-          <div
-            class="w-10 h-full bg-gradient-to-l from-base to-transparent"
-          />
-           
-          <!---->
-        </div>
+        <!---->
          
         <pre
           class="font-mono px-6 py-4 font-base overflow-x-scroll"
         >
           <code>
-            keytool -list -v -keystore your_keystore_name -alias your_alias_name keytool -list -v -keystore your_keystore_name -alias your_alias_name keytool -list -v -keystore your_keystore_name -alias your_alias_name keytool -list -v -keystore your_keystore_name -alias your_alias_name
+            keytool --list -v \\
+          </code>
+          <code>
+              --keystore your_keystore_name \\
+          </code>
+          <code>
+              --
+            <span
+              class="hljs-built_in"
+            >
+              alias
+            </span>
+             your_alias_name
+          </code>
+        </pre>
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="code-block text-font-primary rounded border border-alt text-14 group mb-4 bg-base"
+  >
+    <header
+      class="flex h-10 px-6 font-semibold items-center border-b border-alt text-font-alt2 relative z-10"
+    >
+      <div
+        class="title"
+      >
+        <!---->
+        
+      Example cURL
+    
+      </div>
+       
+      <div
+        class="copy ml-auto"
+      >
+        <span
+          class="icon relative cursor-pointer md icon-clipboard"
+        >
+          <!---->
+        </span>
+      </div>
+    </header>
+     
+    <div
+      class="wrapper"
+    >
+      <!---->
+       
+      <div
+        class="relative flex"
+      >
+        <!---->
+         
+        <pre
+          class="font-mono px-6 py-4 font-base overflow-x-scroll"
+        >
+          <code>
+            curl -X POST \\
+          </code>
+          <code>
+            -H 
+            <span
+              class="hljs-string"
+            >
+              "Content-Type: application/json"
+            </span>
+             \\
+          </code>
+          <code>
+            -H 
+            <span
+              class="hljs-string"
+            >
+              "x-client-id: 5c00b13d00b13d0000000000"
+            </span>
+             \\
+          </code>
+          <code>
+            -d 
+            <span
+              class="hljs-string"
+            >
+              'query { }'
+            </span>
+             \\
+          </code>
+          <code>
+            http://api.chargetrip.io/graphql
+          </code>
+        </pre>
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="code-block text-font-primary rounded border border-alt text-14 group mb-4 bg-base"
+  >
+    <header
+      class="flex h-10 px-6 font-semibold items-center border-b border-alt text-font-alt2 relative z-10"
+    >
+      <div
+        class="title"
+      >
+        <!---->
+        
+      Request (GraphQL)
+    
+      </div>
+       
+      <div
+        class="copy ml-auto"
+      >
+        <span
+          class="icon relative cursor-pointer md icon-clipboard"
+        >
+          <!---->
+        </span>
+      </div>
+    </header>
+     
+    <div
+      class="wrapper"
+    >
+      <!---->
+       
+      <div
+        class="relative flex"
+      >
+        <!---->
+         
+        <pre
+          class="font-mono px-6 py-4 font-base overflow-x-scroll"
+        >
+          <code>
+            <span
+              class="hljs-comment"
+            >
+              # Example query
+            </span>
+          </code>
+          <code>
+            <span
+              class="hljs-keyword"
+            >
+              mutation
+            </span>
+             addReview(
+            <span
+              class="hljs-variable"
+            >
+              $stationId
+            </span>
+            :
+            <span
+              class="hljs-type"
+            >
+               String
+            </span>
+            !, 
+            <span
+              class="hljs-variable"
+            >
+              $carId
+            </span>
+            :
+            <span
+              class="hljs-type"
+            >
+               String
+            </span>
+            ) {
+          </code>
+          <code>
+              addReview(
+          </code>
+          <code>
+                review: {
+          </code>
+          <code>
+                  stationId: 
+            <span
+              class="hljs-variable"
+            >
+              $stationId
+            </span>
+          </code>
+          <code>
+                  rating: 
+            <span
+              class="hljs-number"
+            >
+              5
+            </span>
+          </code>
+          <code>
+                  message: 
+            <span
+              class="hljs-string"
+            >
+              "My review message"
+            </span>
+          </code>
+          <code>
+                  tags: { working: 
+            <span
+              class="hljs-literal"
+            >
+              true
+            </span>
+            , recommended: 
+            <span
+              class="hljs-literal"
+            >
+              true
+            </span>
+             }
+          </code>
+          <code>
+                  locale: 
+            <span
+              class="hljs-string"
+            >
+              "en-US"
+            </span>
+          </code>
+          <code>
+                  ev: 
+            <span
+              class="hljs-variable"
+            >
+              $carId
+            </span>
+          </code>
+          <code>
+                  plugType:
+            <span
+              class="hljs-literal"
+            >
+               CHADEMO
+            </span>
+          </code>
+          <code>
+                }
+          </code>
+          <code>
+              ) {
+          </code>
+          <code>
+                id,
+          </code>
+          <code>
+                createdAt,
+          </code>
+          <code>
+                rating,
+          </code>
+          <code>
+                ev {
+          </code>
+          <code>
+                  make,
+          </code>
+          <code>
+                  carModel,
+          </code>
+          <code>
+                  edition
+          </code>
+          <code>
+                }
+          </code>
+          <code>
+                message,
+          </code>
+          <code>
+              }
+          </code>
+          <code>
+            }
+          </code>
+        </pre>
+      </div>
+    </div>
+  </div>
+   
+  <div
+    class="code-block text-font-primary rounded border border-alt text-14 group mb-4 bg-base"
+  >
+    <header
+      class="flex h-10 px-6 font-semibold items-center border-b border-alt text-font-alt2 relative z-10"
+    >
+      <div
+        class="title"
+      >
+        <!---->
+        
+      Response (JSON)
+    
+      </div>
+       
+      <div
+        class="copy ml-auto"
+      >
+        <span
+          class="icon relative cursor-pointer md icon-clipboard"
+        >
+          <!---->
+        </span>
+      </div>
+    </header>
+     
+    <div
+      class="wrapper"
+    >
+      <!---->
+       
+      <div
+        class="relative flex"
+      >
+        <!---->
+         
+        <pre
+          class="font-mono px-6 py-4 font-base overflow-x-scroll"
+        >
+          <code>
+            {
+          </code>
+          <code>
+              
+            <span
+              class="hljs-attr"
+            >
+              "data"
+            </span>
+            : {
+          </code>
+          <code>
+                
+            <span
+              class="hljs-attr"
+            >
+              "addReview"
+            </span>
+            : {
+          </code>
+          <code>
+                  
+            <span
+              class="hljs-attr"
+            >
+              "id"
+            </span>
+            : 
+            <span
+              class="hljs-string"
+            >
+              "5c00b13d00b13d0000000000"
+            </span>
+            ,
+          </code>
+          <code>
+                  
+            <span
+              class="hljs-attr"
+            >
+              "createdAt"
+            </span>
+            : 
+            <span
+              class="hljs-string"
+            >
+              "2020-12-17T11:37:40Z"
+            </span>
+            ,
+          </code>
+          <code>
+                  
+            <span
+              class="hljs-attr"
+            >
+              "rating"
+            </span>
+            : 
+            <span
+              class="hljs-number"
+            >
+              5
+            </span>
+            ,
+          </code>
+          <code>
+                  
+            <span
+              class="hljs-attr"
+            >
+              "ev"
+            </span>
+            : {
+          </code>
+          <code>
+                    
+            <span
+              class="hljs-attr"
+            >
+              "make"
+            </span>
+            : 
+            <span
+              class="hljs-literal"
+            >
+              null
+            </span>
+            ,
+          </code>
+          <code>
+                    
+            <span
+              class="hljs-attr"
+            >
+              "carModel"
+            </span>
+            : 
+            <span
+              class="hljs-literal"
+            >
+              null
+            </span>
+            ,
+          </code>
+          <code>
+                    
+            <span
+              class="hljs-attr"
+            >
+              "edition"
+            </span>
+            : 
+            <span
+              class="hljs-literal"
+            >
+              null
+            </span>
+          </code>
+          <code>
+                  },
+          </code>
+          <code>
+                  
+            <span
+              class="hljs-attr"
+            >
+              "message"
+            </span>
+            : 
+            <span
+              class="hljs-string"
+            >
+              "My review message"
+            </span>
+          </code>
+          <code>
+                }
+          </code>
+          <code>
+              }
+          </code>
+          <code>
+            }
           </code>
         </pre>
       </div>


### PR DESCRIPTION
This attempts to add highlighting styles based on GitHub's syntax.

GitHub itself uses [`tree-sitter`](https://tree-sitter.github.io/tree-sitter/syntax-highlighting) for more detailed highlighting, which means that we can't have a 1:1 mapping of the styles. If we'd want to do so, we'd have to look into somehow adding it or try to expand the regular expressions in [`utilities/highlight.ts`](https://github.com/chargetrip/internal-vue-components/blob/d8cc74716fb16aa0eeb7263adafdabebbec996b5/src/utilities/highlight.ts).

Light             |  Dark
:-------------------------:|:-------------------------:
![Light mode](https://user-images.githubusercontent.com/12190184/155306542-7fe76f6e-5774-4a65-b6b6-03edc3b4a524.png)  |  ![Dark mode](https://user-images.githubusercontent.com/12190184/155306554-41a2f08f-6d4a-4388-ab21-ae33c03d5b19.png)


